### PR TITLE
feat context: Add support for resource set collections

### DIFF
--- a/context/context.go
+++ b/context/context.go
@@ -80,6 +80,7 @@ func flattenResourceSetCollections(rs *[]ResourceSet) *[]ResourceSet {
 		} else {
 			for _, subResourceSet := range r.Include {
 				subResourceSet.Parent = &r.Name
+				subResourceSet.Name = path.Join(r.Name, subResourceSet.Name)
 				flattened = append(flattened, subResourceSet)
 			}
 		}

--- a/templater/templater.go
+++ b/templater/templater.go
@@ -121,7 +121,7 @@ func applyLimits(rs *[]context.ResourceSet, include *[]string, exclude *[]string
 	// Exclude excluded resource sets
 	excluded := make([]context.ResourceSet, 0)
 	for _, r := range *rs {
-		if !contains(exclude, &r.Name) {
+		if !matchesResourceSet(exclude, &r) {
 			excluded = append(excluded, r)
 		}
 	}
@@ -132,7 +132,7 @@ func applyLimits(rs *[]context.ResourceSet, include *[]string, exclude *[]string
 	}
 	included := make([]context.ResourceSet, 0)
 	for _, r := range excluded {
-		if contains(include, &r.Name) {
+		if matchesResourceSet(include, &r) {
 			included = append(included, r)
 		}
 	}
@@ -140,10 +140,10 @@ func applyLimits(rs *[]context.ResourceSet, include *[]string, exclude *[]string
 	return &included
 }
 
-// Check whether a certain string is contained in a string slice
-func contains(s *[]string, v *string) bool {
+// Check whether an include/exclude string slice matches a resource set
+func matchesResourceSet(s *[]string, rs *context.ResourceSet) bool {
 	for _, r := range *s {
-		if r == *v {
+		if r == rs.Name || r == *rs.Parent {
 			return true
 		}
 	}

--- a/templater/templater.go
+++ b/templater/templater.go
@@ -143,7 +143,7 @@ func applyLimits(rs *[]context.ResourceSet, include *[]string, exclude *[]string
 // Check whether an include/exclude string slice matches a resource set
 func matchesResourceSet(s *[]string, rs *context.ResourceSet) bool {
 	for _, r := range *s {
-		if r == rs.Name || r == *rs.Parent {
+		if r == rs.Name || (rs.Parent != nil && r == *rs.Parent) {
 			return true
 		}
 	}


### PR DESCRIPTION
A resource set collection is a resource set with an addition 'include' array
configured. It is a short-hand for importing multiple resource sets from the
same folder and for excluding/including them as a group.

See https://github.com/tazjin/kontemplate/issues/9 for more information.

Closes #9