### PR TITLE
feat templater: Fail if values are missing

### DIFF
--- a/templater/templater.go
+++ b/templater/templater.go
@@ -16,6 +16,8 @@ import (
 	"github.com/tazjin/kontemplate/util"
 )
 
+const failOnMissingKeys string = "missingkey=error"
+
 // Error that is caused by non-existent template files being specified
 type TemplateNotFoundError struct {
 	meep.AllTraits
@@ -78,7 +80,7 @@ func processFiles(c *context.Context, rs *context.ResourceSet, rp string, files 
 }
 
 func templateFile(c *context.Context, rs *context.ResourceSet, filename string) (string, error) {
-	tpl, err := template.New(path.Base(filename)).Funcs(templateFuncs()).ParseFiles(filename)
+	tpl, err := template.New(path.Base(filename)).Funcs(templateFuncs()).Option(failOnMissingKeys).ParseFiles(filename)
 
 	if err != nil {
 		return "", meep.New(

--- a/templater/templater_test.go
+++ b/templater/templater_test.go
@@ -3,6 +3,7 @@ package templater
 import (
 	"github.com/tazjin/kontemplate/context"
 	"reflect"
+	"strings"
 	"testing"
 )
 
@@ -134,5 +135,21 @@ func TestApplyLimitsExcludeIncludePrecedence(t *testing.T) {
 		t.Error("Result does not contain expected resource sets.")
 		t.Errorf("Expected: %v\nResult: %v\n", expected, *result)
 		t.Fail()
+	}
+}
+
+func TestFailOnMissingKeys(t *testing.T) {
+	ctx := context.Context{}
+	resourceSet := context.ResourceSet{}
+
+	_, err := templateFile(&ctx, &resourceSet, "testdata/test-template.txt")
+
+	if err == nil {
+		t.Errorf("Template with missing keys should have failed.\n")
+		t.Fail()
+	}
+
+	if !strings.Contains(err.Error(), "map has no entry for key \"testName\"") {
+		t.Errorf("Templating failed with unexpected error: %v\n", err)
 	}
 }

--- a/templater/testdata/test-template.txt
+++ b/templater/testdata/test-template.txt
@@ -1,0 +1,1 @@
+Template for test {{ .testName }}


### PR DESCRIPTION
Golang's template package now has an option for failing if template variables
are missing: https://golang.org/pkg/text/template/#Template.Option

This updates the templater code to make use of that option and return the
errors encountered during templating.

This fixes #1