### PR TITLE
fix main: Don't panic if file is unspecified

### DIFF
--- a/main.go
+++ b/main.go
@@ -75,8 +75,11 @@ func applyCommand() cli.Command {
 			include := c.StringSlice("include")
 			exclude := c.StringSlice("exclude")
 			ctx, err := loadContext(c)
-			resources, err := templater.LoadAndPrepareTemplates(&include, &exclude, ctx)
+			if err != nil {
+				return err
+			}
 
+			resources, err := templater.LoadAndPrepareTemplates(&include, &exclude, ctx)
 			if err != nil {
 				return err
 			}
@@ -102,8 +105,11 @@ func replaceCommand() cli.Command {
 			include := c.StringSlice("include")
 			exclude := c.StringSlice("exclude")
 			ctx, err := loadContext(c)
-			resources, err := templater.LoadAndPrepareTemplates(&include, &exclude, ctx)
+			if err != nil {
+				return err
+			}
 
+			resources, err := templater.LoadAndPrepareTemplates(&include, &exclude, ctx)
 			if err != nil {
 				return err
 			}
@@ -122,9 +128,13 @@ func deleteCommand() cli.Command {
 		Action: func(c *cli.Context) error {
 			include := c.StringSlice("include")
 			exclude := c.StringSlice("exclude")
-			ctx, err := loadContext(c)
-			resources, err := templater.LoadAndPrepareTemplates(&include, &exclude, ctx)
 
+			ctx, err := loadContext(c)
+			if err != nil {
+				return err
+			}
+
+			resources, err := templater.LoadAndPrepareTemplates(&include, &exclude, ctx)
 			if err != nil {
 				return err
 			}
@@ -186,7 +196,7 @@ func loadContext(c *cli.Context) (*context.Context, error) {
 		return nil, meep.New(
 			&meep.ErrInvalidParam{
 				Param:  "file",
-				Reason: "Cluster config file must be specified",
+				Reason: "Cluster config file must be specified (-f)",
 			},
 		)
 	}


### PR DESCRIPTION
Instead of printing a spooky stacktrace when the user forgets to specify
the `-f` argument, return an error a lot more gracefully.