### PR TITLE
feat templater: Warn if no valid resource sets are included

### DIFF
--- a/templater/templater.go
+++ b/templater/templater.go
@@ -33,6 +33,11 @@ type TemplatingError struct {
 func LoadAndPrepareTemplates(include *[]string, exclude *[]string, c *context.Context) (output []string, err error) {
 	limitedResourceSets := applyLimits(&c.ResourceSets, include, exclude)
 
+	if len(*limitedResourceSets) == 0 {
+		fmt.Fprintln(os.Stderr, "No valid resource sets included!")
+		return
+	}
+
 	for _, rs := range *limitedResourceSets {
 		err = processResourceSet(c, &rs, &output)
 


### PR DESCRIPTION
After filtering resource sets, check whether any resource sets "survived".

Otherwise it can be assumed that the user specified invalid exclude/include
combinations and should be warned about that.

Fixes #35