### PR TITLE
fix main: Exit with kubectl status code

### DIFF
--- a/build-release.sh
+++ b/build-release.sh
@@ -3,7 +3,7 @@ set -ueo pipefail
 
 readonly GIT_HASH="$(git rev-parse --short HEAD)"
 readonly LDFLAGS="-X main.gitHash=${GIT_HASH} -w -s"
-readonly VERSION="1.0-${GIT_HASH}"
+readonly VERSION="1.0.1-${GIT_HASH}"
 
 function build-for() {
     local os="${1}"

--- a/main.go
+++ b/main.go
@@ -11,7 +11,7 @@ import (
 	"gopkg.in/alecthomas/kingpin.v2"
 )
 
-const version string = "1.0"
+const version string = "1.0.1"
 
 // This variable will be initialised by the Go linker during the builder
 var gitHash string
@@ -155,7 +155,5 @@ func runKubectlWithResources(c *context.Context, kubectlArgs *[]string, resource
 	}
 	stdin.Close()
 
-	kubectl.Wait()
-
-	return nil
+	return kubectl.Wait()
 }


### PR DESCRIPTION
If kubectl fails during a kontemplate run, kontemplate should also
exit with a non-zero status code.

This fixes #43