### PR TITLE
feat build: Add Homebrew binary formula

### DIFF
--- a/kontemplate.rb
+++ b/kontemplate.rb
@@ -1,0 +1,13 @@
+# Homebrew binary formula for Kontemplate
+
+class Kontemplate < Formula
+  desc "Kontemplate - Extremely simple Kubernetes resource templates"
+  homepage "https://github.com/tazjin/kontemplate"
+  url "https://github.com/tazjin/kontemplate/releases/download/v1.0.2/kontemplate-1.0.2-f79b261-darwin-amd64.tar.gz"
+  sha256 "5a2db5467bc77e4379b5b98f35c9864010f7023ae01a25fb5cda1aede59e021c"
+  version "1.0.2-f79b261"
+
+  def install
+    bin.install "kontemplate"
+  end
+end


### PR DESCRIPTION
Adds a Homebrew formula that downloads and installs the 1.0.2 binary release.

Users should be able to "tap" this formula from OS X, the README will be updated in a separate commit.

This fixes #41