### PR TITLE
fix templater: Insert additional resource separators

### DIFF
--- a/templater/templater.go
+++ b/templater/templater.go
@@ -95,6 +95,13 @@ func templateFile(c *context.Context, rs *context.ResourceSet, filename string) 
 	}
 
 	var b bytes.Buffer
+	// For YAML-formatted templates an additional resource separator ('---') will be inserted at the beginning
+	// of the YAML file.
+	// This prevents an error-case in which resources spread out over multiple files may not be recognised as such
+	// if the user forgets to insert a separator manually.
+	if strings.HasSuffix(filename, "yaml") || strings.HasSuffix(filename, "yml") {
+		b.WriteString("---\n")
+	}
 
 	rs.Values = *util.Merge(&c.Global, &rs.Values)
 


### PR DESCRIPTION
In cases where users have multiple resource sets, or a single resource
set that contains multiple YAML files they may run into issues if they
forget to start their resource files with `---`.

This fix inserts an additional `---` at the beginning of each YAML
template.

In cases where the user started their file YAML file "properly" this
will result in an empty resource being templated / passed to kubectl,
however that does not seem to cause any issues.

This fixes #51