### PR TITLE
feat image: Add Dockerfile for CI pipeline image

### DIFF
--- a/image/Dockerfile
+++ b/image/Dockerfile
@@ -1,0 +1,14 @@
+FROM alpine:3.6
+
+ADD hashes /root/hashes
+ADD https://storage.googleapis.com/kubernetes-release/release/v1.6.4/bin/linux/amd64/kubectl /usr/bin/kubectl
+ADD https://github.com/tazjin/kontemplate/releases/download/v1.0.2/kontemplate-1.0.2-f79b261-linux-amd64.tar.gz /tmp/kontemplate.tar.gz
+
+# Pass release version is 1.7.1
+ADD https://raw.githubusercontent.com/zx2c4/password-store/38ec1c72e29c872ec0cdde82f75490640d4019bf/src/password-store.sh /usr/bin/pass
+
+RUN sha256sum -c /root/hashes && \
+    apk add -U bash tree gnupg && \
+    chmod +x /usr/bin/kubectl /usr/bin/pass && \
+    tar xzvf /tmp/kontemplate.tar.gz && \
+    mv kontemplate /usr/bin/kontemplate

--- a/image/README.md
+++ b/image/README.md
@@ -1,0 +1,12 @@
+Kontemplate Docker image
+========================
+
+This builds a simple Docker image available on the Docker Hub as `tazjin/kontemplate`.
+
+Builds are automated based on the Dockerfile contained here.
+
+It contains both `kontemplate` and `kubectl` and can be used as part of container-based
+CI pipelines.
+
+`pass` and its dependencies are also installed to enable the use of the `passLookup`
+template function if desired.

--- a/image/hashes
+++ b/image/hashes
@@ -1,0 +1,2 @@
+156e5592ed3ae6c9aff12fbbed17141ed7b3ede26ed169001df5b1211435f033  /tmp/kontemplate.tar.gz
+a91c6b028bb3f737898ff003f7f3a3f2d242ea52e89ade1f6ca3ab99170119e5  /usr/bin/kubectl


### PR DESCRIPTION
Adds a simple Docker image that can be used in CI pipelines to deploy
`kontemplate`-based environments.

This image contains kontemplate and all of its dependencies (including
pass as an optional dependency).