### PR TITLE
Pass rendered resource sets to kubectl individually

### DIFF
--- a/main.go
+++ b/main.go
@@ -80,10 +80,13 @@ func versionCommand() {
 }
 
 func templateCommand() {
-	_, resources := loadContextAndResources(templateFile)
+	_, resourceSets := loadContextAndResources(templateFile)
 
-	for _, r := range *resources {
-		fmt.Println(r)
+	for _, rs := range *resourceSets {
+		for _, r := range rs.Resources {
+			fmt.Fprintf(os.Stderr, "Rendered file %s/%s:\n", rs.Name, r.Filename)
+			fmt.Println(r.Rendered)
+		}
 	}
 }
 
@@ -163,7 +166,7 @@ func runKubectlWithResources(c *context.Context, kubectlArgs *[]string, resource
 		}
 
 		for _, r := range resourceSet.Resources {
-			fmt.Printf("Passing file %s/%s to kubectl", resourceSet.Name, r.Filename)
+			fmt.Printf("Passing file %s/%s to kubectl\n", resourceSet.Name, r.Filename)
 			fmt.Fprintln(stdin, r.Rendered)
 		}
 		stdin.Close()

--- a/templater/templater.go
+++ b/templater/templater.go
@@ -42,7 +42,7 @@ type RenderedResourceSet struct {
 
 func LoadAndApplyTemplates(include *[]string, exclude *[]string, c *context.Context) ([]RenderedResourceSet, error) {
 	limitedResourceSets := applyLimits(&c.ResourceSets, include, exclude)
-	renderedResourceSets := make([]RenderedResourceSet, len(c.ResourceSets))
+	renderedResourceSets := make([]RenderedResourceSet, 0)
 
 	if len(*limitedResourceSets) == 0 {
 		return renderedResourceSets, fmt.Errorf("No valid resource sets included!")
@@ -83,7 +83,7 @@ func processResourceSet(c *context.Context, rs *context.ResourceSet) (*RenderedR
 }
 
 func processFiles(c *context.Context, rs *context.ResourceSet, rp string, files []os.FileInfo) ([]RenderedResource, error) {
-	resources := make([]RenderedResource, len(c.ResourceSets))
+	resources := make([]RenderedResource, 0)
 
 	for _, file := range files {
 		if !file.IsDir() && isResourceFile(file) {


### PR DESCRIPTION
Please see the individual commits for more information. This resolves #51 and #56, but does not yet implement the missing resource separator warning inside of a single resource set.