### PR TITLE
fix templater: Ignore slash-suffixes on includes/excludes

### DIFF
--- a/templater/templater.go
+++ b/templater/templater.go
@@ -163,6 +163,7 @@ func applyLimits(rs *[]context.ResourceSet, include *[]string, exclude *[]string
 // Check whether an include/exclude string slice matches a resource set
 func matchesResourceSet(s *[]string, rs *context.ResourceSet) bool {
 	for _, r := range *s {
+		r = strings.TrimSuffix(r, "/")
 		if r == rs.Name || r == rs.Parent {
 			return true
 		}


### PR DESCRIPTION
To prevent situations where a shell auto-appends a slash to an
include/exclude specification on the CLI, trailing slashes in those
string lists are now trimmed.

This fixes #54