### PR TITLE
Support fetching resources from Kubernetes

### DIFF
--- a/main.go
+++ b/main.go
@@ -177,6 +177,6 @@ func runKubectlWithResources(c *context.Context, kubectlArgs *[]string, resource
 }
 
 func failWithKubectlError(err error) {
-	fmt.Errorf("Kubectl error: %v\n", err)
+	fmt.Fprintf(os.Stderr, "Kubectl error: %v\n", err)
 	os.Exit(1)
 }

--- a/main.go
+++ b/main.go
@@ -8,6 +8,7 @@ import (
 	"github.com/polydawn/meep"
 	"github.com/tazjin/kontemplate/context"
 	"github.com/tazjin/kontemplate/templater"
+	"github.com/tazjin/kontemplate/util"
 	"gopkg.in/alecthomas/kingpin.v2"
 )
 
@@ -15,10 +16,6 @@ const version string = "1.1.0"
 
 // This variable will be initialised by the Go linker during the builder
 var gitHash string
-
-type KubeCtlError struct {
-	meep.AllTraits
-}
 
 var (
 	app = kingpin.New("kontemplate", "simple Kubernetes resource templating")
@@ -155,14 +152,14 @@ func runKubectlWithResources(c *context.Context, kubectlArgs *[]string, resource
 
 		stdin, err := kubectl.StdinPipe()
 		if err != nil {
-			return meep.New(&KubeCtlError{}, meep.Cause(err))
+			return meep.New(&util.KubeCtlError{}, meep.Cause(err))
 		}
 
 		kubectl.Stdout = os.Stdout
 		kubectl.Stderr = os.Stderr
 
 		if err = kubectl.Start(); err != nil {
-			return meep.New(&KubeCtlError{}, meep.Cause(err))
+			return meep.New(&util.KubeCtlError{Args: args}, meep.Cause(err))
 		}
 
 		for _, r := range resourceSet.Resources {

--- a/templater/get_resource.go
+++ b/templater/get_resource.go
@@ -11,21 +11,17 @@ import (
 	"github.com/tazjin/kontemplate/util"
 )
 
-func GetResource(c *context.Context, kind string, name string, namespace string) (string, error) {
-	if namespace == "" {
-		namespace = "default"
-	}
-
+func GetResource(c *context.Context, namespace, kind, name string) (string, error) {
 	fmt.Fprintf(os.Stderr, "Attempting to retrieve last applied configuration for %s %s in namespace %s",
 		kind, name, namespace)
 
-	return getLastAppliedConfiguration(c, kind, name, namespace)
+	return getLastAppliedConfiguration(c, namespace, name, kind)
 }
 
 // Retrieves the last applied configuration of a resource. Kontemplate always uses the correct flags to store the
 // necessary annotation, but this may not work with resources created using 'kubectl create' by other tools.
 // The call requires at least kubectl v1.6.0.
-func getLastAppliedConfiguration(c *context.Context, kind string, name string, namespace string) (string, error) {
+func getLastAppliedConfiguration(c *context.Context, namespace, kind, name string) (string, error) {
 	args := []string{
 		fmt.Sprintf("--context=%s", c.Name),
 		fmt.Sprintf("--namespace=%s", namespace),
@@ -54,5 +50,5 @@ func getLastAppliedConfiguration(c *context.Context, kind string, name string, n
 		}, meep.Cause(err))
 	}
 
-	return w.String(), nilsu
+	return w.String(), nil
 }

--- a/templater/get_resource.go
+++ b/templater/get_resource.go
@@ -1,0 +1,58 @@
+package templater
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"os/exec"
+
+	"github.com/polydawn/meep"
+	"github.com/tazjin/kontemplate/context"
+	"github.com/tazjin/kontemplate/util"
+)
+
+func GetResource(c *context.Context, kind string, name string, namespace string) (string, error) {
+	if namespace == "" {
+		namespace = "default"
+	}
+
+	fmt.Fprintf(os.Stderr, "Attempting to retrieve last applied configuration for %s %s in namespace %s",
+		kind, name, namespace)
+
+	return getLastAppliedConfiguration(c, kind, name, namespace)
+}
+
+// Retrieves the last applied configuration of a resource. Kontemplate always uses the correct flags to store the
+// necessary annotation, but this may not work with resources created using 'kubectl create' by other tools.
+// The call requires at least kubectl v1.6.0.
+func getLastAppliedConfiguration(c *context.Context, kind string, name string, namespace string) (string, error) {
+	args := []string{
+		fmt.Sprintf("--context=%s", c.Name),
+		fmt.Sprintf("--namespace=%s", namespace),
+		"apply", "view-last-applied", kind, name,
+	}
+
+	kubectl := exec.Command("kubectl", args...)
+
+	w := bytes.NewBuffer([]byte{})
+	kubectl.Stdout = w
+
+	e := bytes.NewBuffer([]byte{})
+	kubectl.Stderr = e
+
+	if err := kubectl.Start(); err != nil {
+		return "", meep.New(&util.KubeCtlError{
+			Args:   args,
+			Stderr: e.String(),
+		}, meep.Cause(err))
+	}
+
+	if err := kubectl.Wait(); err != nil {
+		return "", meep.New(&util.KubeCtlError{
+			Args:   args,
+			Stderr: e.String(),
+		}, meep.Cause(err))
+	}
+
+	return w.String(), nilsu
+}

--- a/templater/templater.go
+++ b/templater/templater.go
@@ -106,7 +106,7 @@ func processFiles(c *context.Context, rs *context.ResourceSet, rp string, files 
 }
 
 func templateFile(c *context.Context, rs *context.ResourceSet, filename string) (string, error) {
-	tpl, err := template.New(path.Base(filename)).Funcs(templateFuncs()).Option(failOnMissingKeys).ParseFiles(filename)
+	tpl, err := template.New(path.Base(filename)).Funcs(templateFuncs(c)).Option(failOnMissingKeys).ParseFiles(filename)
 
 	if err != nil {
 		return "", meep.New(
@@ -172,13 +172,16 @@ func matchesResourceSet(s *[]string, rs *context.ResourceSet) bool {
 	return false
 }
 
-func templateFuncs() template.FuncMap {
+func templateFuncs(c *context.Context) template.FuncMap {
 	m := sprig.TxtFuncMap()
 	m["json"] = func(data interface{}) string {
 		b, _ := json.Marshal(data)
 		return string(b)
 	}
 	m["passLookup"] = GetFromPass
+	m["getResource"] = func(kind, name string, namespace string) (string, error) {
+		return GetResource(c, kind, name, namespace)
+	}
 
 	return m
 }

--- a/util/util.go
+++ b/util/util.go
@@ -1,5 +1,19 @@
 package util
 
+import "github.com/polydawn/meep"
+
+// Common error type for kubectl calls
+type KubeCtlError struct {
+	meep.TraitAutodescribing
+	meep.TraitCausable
+
+	// The argument list that kubectl was called with
+	Args []string
+
+	// Kubectl stderr (if present)
+	Stderr string
+}
+
 // Merges two maps together. Values from the second map override values in the first map.
 // The returned map is new if anything was changed.
 func Merge(in1 *map[string]interface{}, in2 *map[string]interface{}) *map[string]interface{} {


### PR DESCRIPTION
Adds support for a `getResource(namespace, kind, name)` template function which can insert the last applied configuration of a resource in a template.

This is useful for doing things like this:

```
---
kind: ConfigMap
metadata:
  name: some-config
# <snip! Imagine some data here.>
---
kind: Deployment
# <stuff>
template:
  metadata:
    annotations:
      some-config-hash: '{{ getResource "default" "configmap" "some-config" | sha256sum }}'
```

which will cause rolling updates based on the current configmap configuration.

Another useful effect of this is that this can be used even if the dependent resource is not managed by Kubernetes, for example a certificate `Secret` created by [kubernetes-letsencrypt](https://github.com/tazjin/kubernetes-letsencrypt).