### PR TITLE
Support importing additional variables from files 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 ---
 language: go
 before_script:
+  - if [[ -n "$(go fmt ./...)" ]]; then echo 'Run go fmt!' && exit 1; fi
   - go vet ./...

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,1 +1,4 @@
+---
 language: go
+before_script:
+  - go vet ./...

--- a/context/context_test.go
+++ b/context/context_test.go
@@ -159,3 +159,47 @@ func TestDefaultValuesLoading(t *testing.T) {
 		t.Fail()
 	}
 }
+
+func TestImportValuesLoading(t *testing.T) {
+	ctx, err := LoadContextFromFile("testdata/import-vars-simple.yaml")
+	if err != nil {
+		t.Error(err)
+		t.Fail()
+	}
+
+	expected := map[string]interface{}{
+		"override": "true",
+		"music": map[string]interface{}{
+			"artist": "Pallida",
+			"track":  "Tractor Beam",
+		},
+	}
+
+	if !reflect.DeepEqual(ctx.Global, expected) {
+		t.Error("Expected global values after loading imports did not match!")
+		t.Fail()
+	}
+}
+
+func TestImportValuesOverride(t *testing.T) {
+	ctx, err := LoadContextFromFile("testdata/import-vars-override.yaml")
+	if err != nil {
+		t.Error(err)
+		t.Fail()
+	}
+
+	expected := map[string]interface{}{
+		"override": float64(3),
+		"music": map[string]interface{}{
+			"artist": "Pallida",
+			"track":  "Tractor Beam",
+		},
+		"place":     "Oslo",
+		"globalVar": "very global!",
+	}
+
+	if !reflect.DeepEqual(ctx.Global, expected) {
+		t.Error("Expected global values after loading imports did not match!")
+		t.Fail()
+	}
+}

--- a/context/testdata/import-vars-override.yaml
+++ b/context/testdata/import-vars-override.yaml
@@ -1,0 +1,9 @@
+---
+context: k8s.prod.mydomain.com
+global:
+  globalVar: very global!
+  override: 1
+import:
+  - test-vars.yaml
+  - test-vars-override.yaml
+include: []

--- a/context/testdata/import-vars-simple.yaml
+++ b/context/testdata/import-vars-simple.yaml
@@ -1,0 +1,5 @@
+---
+context: k8s.prod.mydomain.com
+import:
+  - test-vars.yaml
+include: []

--- a/context/testdata/test-vars-override.yaml
+++ b/context/testdata/test-vars-override.yaml
@@ -1,0 +1,3 @@
+---
+override: 3
+place: Oslo

--- a/context/testdata/test-vars.yaml
+++ b/context/testdata/test-vars.yaml
@@ -1,0 +1,5 @@
+---
+override: 'true'
+music:
+  artist: Pallida
+  track: Tractor Beam

--- a/main.go
+++ b/main.go
@@ -180,6 +180,6 @@ func runKubectlWithResources(c *context.Context, kubectlArgs *[]string, resource
 }
 
 func failWithKubectlError(err error) {
-	fmt.Errorf("Kubectl error: %v\n", err)
+	fmt.Fprintf(os.Stderr, "Kubectl error: %v\n", err)
 	os.Exit(1)
 }

--- a/util/util.go
+++ b/util/util.go
@@ -1,5 +1,14 @@
 package util
 
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"strings"
+
+	"github.com/ghodss/yaml"
+)
+
 // Merges two maps together. Values from the second map override values in the first map.
 // The returned map is new if anything was changed.
 func Merge(in1 *map[string]interface{}, in2 *map[string]interface{}) *map[string]interface{} {
@@ -21,4 +30,22 @@ func Merge(in1 *map[string]interface{}, in2 *map[string]interface{}) *map[string
 	}
 
 	return &new
+}
+
+// Loads either a YAML or JSON file from the specified path and deserialises it into the provided interface.
+func LoadJsonOrYaml(filename string, addr interface{}) error {
+	file, err := ioutil.ReadFile(filename)
+	if err != nil {
+		return err
+	}
+
+	if strings.HasSuffix(filename, "json") {
+		err = json.Unmarshal(file, addr)
+	} else if strings.HasSuffix(filename, "yaml") || strings.HasSuffix(filename, "yml") {
+		err = yaml.Unmarshal(file, addr)
+	} else {
+		return fmt.Errorf("File format not supported. Must be JSON or YAML.")
+	}
+
+	return nil
 }


### PR DESCRIPTION
Kontemplate context specifications can now load extra variables from YAML or JSON files by specifying a list of files (relative to the context file) under the `import` key.

This is still missing documentation, but I may redo some parts of the documentation anyways as it was pointed out to me that the default-value functionality is non-obvious, too.

cc: @Globegitter

This implements #64