### PR TITLE
Allow overriding of resource set paths

### DIFF
--- a/context/context_test.go
+++ b/context/context_test.go
@@ -21,6 +21,7 @@ func TestLoadFlatContextFromFile(t *testing.T) {
 		ResourceSets: []ResourceSet{
 			{
 				Name: "some-api",
+				Path: "some-api",
 				Values: map[string]interface{}{
 					"apiPort":          float64(4567), // yep!
 					"importantFeature": true,
@@ -55,6 +56,7 @@ func TestLoadContextWithResourceSetCollections(t *testing.T) {
 		ResourceSets: []ResourceSet{
 			{
 				Name: "some-api",
+				Path: "some-api",
 				Values: map[string]interface{}{
 					"apiPort":          float64(4567), // yep!
 					"importantFeature": true,
@@ -65,6 +67,7 @@ func TestLoadContextWithResourceSetCollections(t *testing.T) {
 			},
 			{
 				Name: "collection/nested",
+				Path: "collection/nested",
 				Values: map[string]interface{}{
 					"lizards": "good",
 				},
@@ -95,6 +98,7 @@ func TestSubresourceVariableInheritance(t *testing.T) {
 		ResourceSets: []ResourceSet{
 			{
 				Name: "parent/child",
+				Path: "parent/child",
 				Values: map[string]interface{}{
 					"foo": "bar",
 					"bar": "baz",
@@ -125,6 +129,7 @@ func TestSubresourceVariableInheritanceOverride(t *testing.T) {
 		ResourceSets: []ResourceSet{
 			{
 				Name: "parent/child",
+				Path: "parent/child",
 				Values: map[string]interface{}{
 					"foo": "newvalue",
 				},
@@ -200,6 +205,69 @@ func TestImportValuesOverride(t *testing.T) {
 
 	if !reflect.DeepEqual(ctx.Global, expected) {
 		t.Error("Expected global values after loading imports did not match!")
+		t.Fail()
+	}
+}
+
+func TestExplicitPathLoading(t *testing.T) {
+	ctx, err := LoadContextFromFile("testdata/explicit-path.yaml")
+	if err != nil {
+		t.Error(err)
+		t.Fail()
+	}
+
+	expected := Context{
+		Name: "k8s.prod.mydomain.com",
+		ResourceSets: []ResourceSet{
+			{
+				Name: "some-api-europe",
+				Path: "some-api",
+				Values: map[string]interface{}{
+					"location": "europe",
+				},
+				Include: nil,
+				Parent:  "",
+			},
+			{
+				Name: "some-api-asia",
+				Path: "some-api",
+				Values: map[string]interface{}{
+					"location": "asia",
+				},
+				Include: nil,
+				Parent:  "",
+			},
+		},
+		BaseDir: "testdata",
+	}
+
+	if !reflect.DeepEqual(*ctx, expected) {
+		t.Error("Loaded context and expected context did not match")
+		t.Fail()
+	}
+}
+
+func TestExplicitSubresourcePathLoading(t *testing.T) {
+	ctx, err := LoadContextFromFile("testdata/explicit-subresource-path.yaml")
+	if err != nil {
+		t.Error(err)
+		t.Fail()
+	}
+
+	expected := Context{
+		Name: "k8s.prod.mydomain.com",
+		ResourceSets: []ResourceSet{
+			{
+				Name:   "parent/child",
+				Path:   "parent-path/child-path",
+				Parent: "parent",
+			},
+		},
+		BaseDir: "testdata",
+	}
+
+	if !reflect.DeepEqual(*ctx, expected) {
+		t.Error("Loaded context and expected context did not match")
 		t.Fail()
 	}
 }

--- a/context/testdata/explicit-path.yaml
+++ b/context/testdata/explicit-path.yaml
@@ -1,0 +1,11 @@
+---
+context: k8s.prod.mydomain.com
+include:
+  - name: some-api-europe
+    path: some-api
+    values:
+      location: europe
+  - name: some-api-asia
+    path: some-api
+    values:
+      location: asia

--- a/context/testdata/explicit-subresource-path.yaml
+++ b/context/testdata/explicit-subresource-path.yaml
@@ -1,0 +1,8 @@
+---
+context: k8s.prod.mydomain.com
+include:
+  - name: parent
+    path: parent-path
+    include:
+      - name: child
+        path: child-path

--- a/templater/templater.go
+++ b/templater/templater.go
@@ -22,6 +22,7 @@ const failOnMissingKeys string = "missingkey=error"
 type TemplateNotFoundError struct {
 	meep.AllTraits
 	Name string
+	Path string
 }
 
 // Error that is caused during templating, e.g. required value being absent or invalid template format
@@ -64,14 +65,14 @@ func LoadAndApplyTemplates(include *[]string, exclude *[]string, c *context.Cont
 func processResourceSet(c *context.Context, rs *context.ResourceSet) (*RenderedResourceSet, error) {
 	fmt.Fprintf(os.Stderr, "Loading resources for %s\n", rs.Name)
 
-	rp := path.Join(c.BaseDir, rs.Name)
+	rp := path.Join(c.BaseDir, rs.Path)
 	files, err := ioutil.ReadDir(rp)
 
 	resources, err := processFiles(c, rs, rp, files)
 
 	if err != nil {
 		return nil, meep.New(
-			&TemplateNotFoundError{Name: rs.Name},
+			&TemplateNotFoundError{Name: rs.Name, Path: rs.Path},
 			meep.Cause(err),
 		)
 	}


### PR DESCRIPTION
Instead of always inferring the path at which files in a resource set
are located, let users override the path by specifying a `path` field.

This makes it possible to add the same resource set multiple times
with different values while still keeping distinct names for
addressability (for example when using include/exclude).

This fixes #70