### PR TITLE
Bump Dockerfile and Homebrew versions

### DIFF
--- a/image/Dockerfile
+++ b/image/Dockerfile
@@ -1,8 +1,8 @@
 FROM alpine:3.6
 
 ADD hashes /root/hashes
-ADD https://storage.googleapis.com/kubernetes-release/release/v1.6.4/bin/linux/amd64/kubectl /usr/bin/kubectl
-ADD https://github.com/tazjin/kontemplate/releases/download/v1.1.0/kontemplate-1.1.0-f7ce04e-linux-amd64.tar.gz /tmp/kontemplate.tar.gz
+ADD https://storage.googleapis.com/kubernetes-release/release/v1.7.4/bin/linux/amd64/kubectl /usr/bin/kubectl
+ADD https://github.com/tazjin/kontemplate/releases/download/v1.2.0/kontemplate-1.2.0-f8b6ad6-linux-amd64.tar.gz /tmp/kontemplate.tar.gz
 
 # Pass release version is 1.7.1
 ADD https://raw.githubusercontent.com/zx2c4/password-store/38ec1c72e29c872ec0cdde82f75490640d4019bf/src/password-store.sh /usr/bin/pass

--- a/image/hashes
+++ b/image/hashes
@@ -1,2 +1,2 @@
-f2bdd1d458b2fad935f1f64e0a40d59b28be6b0debbc20241e1d8ad4a77a7cc2  /tmp/kontemplate.tar.gz
-a91c6b028bb3f737898ff003f7f3a3f2d242ea52e89ade1f6ca3ab99170119e5  /usr/bin/kubectl
+fd62f9732e53a18748c6afe5854b62ec5c8b56e140b4a78baf100089d3961d03  /tmp/kontemplate.tar.gz
+fb5a961a6ba55093691228d71e64bffd57ada98226f195c409ce297d1cb5086a  /usr/bin/kubectl

--- a/kontemplate.rb
+++ b/kontemplate.rb
@@ -3,9 +3,9 @@
 class Kontemplate < Formula
   desc "Kontemplate - Extremely simple Kubernetes resource templates"
   homepage "https://github.com/tazjin/kontemplate"
-  url "https://github.com/tazjin/kontemplate/releases/download/v1.1.0/kontemplate-1.1.0-f7ce04e-darwin-amd64.tar.gz"
-  sha256 "1dccc80804589f6bd233dd79f52527f2ba8c4fa8d38857c80b2f47b504fe6c04"
-  version "1.1.0-f7ce04e"
+  url "https://github.com/tazjin/kontemplate/releases/download/v1.2.0/kontemplate-1.2.0-f8b6ad6-darwin-amd64.tar.gz"
+  sha256 "0cda70956b4d4e4944d5760970aaf20d586ef9d62ee90e2d67b70f03ed85e075"
+  version "1.2.0-f8b6ad6"
 
   def install
     bin.install "kontemplate"


### PR DESCRIPTION
There is something weird going on with the Dockerfile: In some versions of Docker (`*sigh*`) the `ADD` instruction will now *extract* remote-downloaded archives (it previously (?) only extracted archives if copied from local disk).

This means that the signature verification will break because it expects a file on disk, however it still seems to work "correctly" on Docker Hub's build system so I should get this out asap.