### PR TITLE
fix templater: Don't template default.yml files

### DIFF
--- a/context/context.go
+++ b/context/context.go
@@ -143,9 +143,7 @@ func loadAllDefaultValues(c *Context) []ResourceSet {
 func loadDefaultValues(rs *ResourceSet, c *Context) *map[string]interface{} {
 	var defaultVars map[string]interface{}
 
-	defaultFilenames := []string{"default.yml", "default.yaml", "default.json"}
-
-	for _, filename := range defaultFilenames {
+	for _, filename := range util.DefaultFilenames {
 		err := util.LoadJsonOrYaml(path.Join(c.BaseDir, rs.Path, filename), &defaultVars)
 		if err == nil {
 			return util.Merge(&defaultVars, &rs.Values)

--- a/templater/templater.go
+++ b/templater/templater.go
@@ -186,8 +186,10 @@ func templateFuncs() template.FuncMap {
 
 // Checks whether a file is a resource file (i.e. is YAML or JSON) and not a default values file.
 func isResourceFile(f os.FileInfo) bool {
-	if f.Name() == "default.json" || f.Name() == "default.yaml" {
-		return false
+	for _, defaultFile := range util.DefaultFilenames {
+		if f.Name() == defaultFile {
+			return false
+		}
 	}
 
 	return strings.HasSuffix(f.Name(), "yaml") ||

--- a/util/util.go
+++ b/util/util.go
@@ -9,6 +9,9 @@ import (
 	"github.com/ghodss/yaml"
 )
 
+// Filenames excluded from templating for the purpose of containing default variable values inside a resource set.
+var DefaultFilenames []string = []string{"default.yml", "default.yaml", "default.json"}
+
 // Merges two maps together. Values from the second map override values in the first map.
 // The returned map is new if anything was changed.
 func Merge(in1 *map[string]interface{}, in2 *map[string]interface{}) *map[string]interface{} {


### PR DESCRIPTION
After the change from #84 default variable files with the '.yml'
extension got templated as resource set templates accidentally.

This resolves the issue by moving the list reserved default file names
to a common place and reusing it in both the templater and context pkg.

This fixes #85