### PR TITLE
Ensure that nonexistent / empty resource sets are handled correctly

### DIFF
--- a/main.go
+++ b/main.go
@@ -85,7 +85,7 @@ func templateCommand() {
 	for _, rs := range *resourceSets {
 		if len(rs.Resources) == 0 {
 			fmt.Fprintf(os.Stderr, "Warning: Resource set '%s' contains no valid templates\n", rs.Name)
-			break
+			continue
 		}
 
 		for _, r := range rs.Resources {

--- a/main.go
+++ b/main.go
@@ -84,7 +84,7 @@ func templateCommand() {
 
 	for _, rs := range *resourceSets {
 		if len(rs.Resources) == 0 {
-			fmt.Fprintf(os.Stderr, "Warning: Resource set '%s' contains no valid templates\n", rs.Name)
+			fmt.Fprintf(os.Stderr, "Warning: Resource set '%s' does not exist or contains no valid templates\n", rs.Name)
 			continue
 		}
 

--- a/templater/templater.go
+++ b/templater/templater.go
@@ -66,7 +66,10 @@ func processResourceSet(c *context.Context, rs *context.ResourceSet) (*RenderedR
 	fmt.Fprintf(os.Stderr, "Loading resources for %s\n", rs.Name)
 
 	rp := path.Join(c.BaseDir, rs.Path)
-	files, err := ioutil.ReadDir(rp)
+
+	// Explicitly discard this error, which will give us an empty list of files instead.
+	// This will end up printing a warning to the user, but it won't stop the rest of the process.
+	files, _ := ioutil.ReadDir(rp)
 
 	resources, err := processFiles(c, rs, rp, files)
 


### PR DESCRIPTION
There were some minor, tricky issues with this. Maybe I need some testing around the execution of the whole process, or maybe #72 so I can test this somewhat more easily.