### PR TITLE
Version 1.3.0

### DIFF
--- a/build-release.sh
+++ b/build-release.sh
@@ -3,7 +3,7 @@ set -ueo pipefail
 
 readonly GIT_HASH="$(git rev-parse --short HEAD)"
 readonly LDFLAGS="-X main.gitHash=${GIT_HASH} -w -s"
-readonly VERSION="1.2.0-${GIT_HASH}"
+readonly VERSION="1.3.0-${GIT_HASH}"
 
 function binary-name() {
     local os="${1}"

--- a/kontemplate.frm
+++ b/kontemplate.frm
@@ -73,7 +73,7 @@ action:
       echo 'nameserver 8.8.8.8' > /etc/resolv.conf
       apt-get update && apt-get install -y git ca-certificates
       mkdir -p /go/src/github.com/tazjin
-      git clone --single-branch --branch v1.2.0 https://github.com/tazjin/kontemplate /go/src/github.com/tazjin/kontemplate
+      git clone --single-branch --branch v1.3.0 https://github.com/tazjin/kontemplate /go/src/github.com/tazjin/kontemplate
       cd /go/src/github.com/tazjin/kontemplate
       ./build-release.sh build
 outputs:

--- a/main.go
+++ b/main.go
@@ -11,7 +11,7 @@ import (
 	"gopkg.in/alecthomas/kingpin.v2"
 )
 
-const version string = "1.2.0"
+const version string = "1.3.0"
 
 // This variable will be initialised by the Go linker during the builder
 var gitHash string


### PR DESCRIPTION
This release comes with minor usability improvements and features.

* A new 'lookupIPAddr' template function is available for resolving
  DNS A records in templates. Thanks to @landro for the pull request!

* Handling of "non-standard" resource set structures has been improved
  to result in better error messages and behaviour in several places.

Release binaries are signed with GPG key `66F505681DB8F43B` which is
verified on my Github profile.

--------------

Note: This is the last Kontemplate release that will be written in Go.

Rob Pike's art project has proven its point but I believe it is
ethically questionable and morally indefensible to continue on this
path.

You can track #72 for the Rust-rewrite of Kontemplate.