### PR TITLE
File include support for kontemplate

### DIFF
--- a/docs/templates.md
+++ b/docs/templates.md
@@ -72,10 +72,11 @@ right.
 
 Some template functions come from Go's standard library and are listed in the
 [Go documentation][]. In addition the functions declared by [sprig][] are
-available in kontemplate, as well as two custom functions:
+available in kontemplate, as well as three custom functions:
 
 `json`: Encodes any supplied data structure as JSON.
 `passLookup`: Looks up the supplied key in [pass][]
+`fromFile`: Pastes the content of the given files name.
 
 ## Examples:
 

--- a/example/some-api/some-api.yaml
+++ b/example/some-api/some-api.yaml
@@ -25,6 +25,8 @@ spec:
               value: {{ .importantFeature }}
             - name: SOME_GLOBAL_VAR
               value: {{ .globalVar }}
+            - name: FILE_VAR
+              value: {{ fileContent "some-api/filevar.txt" }}
 ---
 apiVersion: v1
 kind: Service

--- a/templater/fromfile.go
+++ b/templater/fromfile.go
@@ -1,0 +1,24 @@
+// Copyright (C) 2017  Niklas Wik <niklas.wik@nokia.com>
+//
+// This file is part of Kontemplate.
+//
+// Kontemplate is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+package templater
+
+import (
+	"io/ioutil"
+)
+
+//GetFromFile returns file content as string
+func GetFromFile(file string) (string, error) {
+
+	data, err := ioutil.ReadFile(file)
+	if err != nil {
+		return "", err
+	}
+	return string(data), nil
+}

--- a/templater/templater.go
+++ b/templater/templater.go
@@ -193,6 +193,7 @@ func templateFuncs() template.FuncMap {
 	}
 	m["passLookup"] = GetFromPass
 	m["lookupIPAddr"] = GetIPsFromDNS
+	m["fileContent"] = GetFromFile
 
 	return m
 }


### PR DESCRIPTION
- Include is relative to directory where kontemplate yaml is located.
- Example added to docs.

Implements #46 