### PR TITLE
Explicitly add triple dash at start of each template to pass to kubectl

### DIFF
--- a/main.go
+++ b/main.go
@@ -192,7 +192,7 @@ func runKubectlWithResources(c *context.Context, kubectlArgs *[]string, resource
 
 		for _, r := range rs.Resources {
 			fmt.Printf("Passing file %s/%s to kubectl\n", rs.Name, r.Filename)
-			fmt.Fprintln(stdin, r.Rendered)
+			fmt.Fprintf(stdin, "---\n%s\n", r.Rendered)
 		}
 		stdin.Close()
 


### PR DESCRIPTION
Hi,
It seems that in YAML Spec it's optional to start a file with triple dash if there is only one document. Since kontemplate concat config files and each file can potentially contain only one document, it can be necessary to explicitly add triple dash between each file before sending it to stdin. It's harmless if they are already here.