### PR TITLE
refactor: Remove old error handling library

### DIFF
--- a/context/context.go
+++ b/context/context.go
@@ -10,9 +10,9 @@
 package context
 
 import (
+	"fmt"
 	"path"
 
-	"github.com/polydawn/meep"
 	"github.com/tazjin/kontemplate/util"
 )
 
@@ -51,9 +51,8 @@ type Context struct {
 	BaseDir string
 }
 
-type ContextLoadingError struct {
-	meep.AllTraits
-	Filename string
+func contextLoadingError(filename string, cause error) error {
+	return fmt.Errorf("Context loading failed on file %s due to: \n%v", filename, cause)
 }
 
 // Attempt to load and deserialise a Context from the specified file.
@@ -62,10 +61,7 @@ func LoadContextFromFile(filename string) (*Context, error) {
 	err := util.LoadJsonOrYaml(filename, &c)
 
 	if err != nil {
-		return nil, meep.New(
-			&ContextLoadingError{Filename: filename},
-			meep.Cause(err),
-		)
+		return nil, contextLoadingError(filename, err)
 	}
 
 	c.ResourceSets = flattenPrepareResourceSetPaths(&c.ResourceSets)
@@ -74,10 +70,7 @@ func LoadContextFromFile(filename string) (*Context, error) {
 
 	err = c.loadImportedVariables()
 	if err != nil {
-		return nil, meep.New(
-			&ContextLoadingError{Filename: filename},
-			meep.Cause(err),
-		)
+		return nil, contextLoadingError(filename, err)
 	}
 
 	return &c, nil

--- a/deps.nix
+++ b/deps.nix
@@ -73,15 +73,6 @@
     };
   }
   {
-    goPackagePath = "github.com/polydawn/meep";
-    fetch = {
-      type   = "git";
-      url    = "https://github.com/polydawn/meep";
-      rev    = "eaf1db2168fe380b4da17a35f0adddb5ae15a651";
-      sha256 = "12n134fb2imnj67xkbznzm0gqkg36hdxwr960y91qb5s2q2krxir";
-    };
-  }
-  {
     goPackagePath = "github.com/satori/go.uuid";
     fetch = {
       type   = "git";

--- a/example/some-api/some-api.yaml
+++ b/example/some-api/some-api.yaml
@@ -4,7 +4,7 @@ kind: Secret
 metadata:
   name: secret-certificate
 data:
-  cert.pem: { passLookup "my/secret/certificate" | b64enc }}
+  cert.pem: {{ passLookup "my/secret/certificate" | b64enc }}
 ---
 apiVersion: extensions/v1beta1
 kind: ConfigMap

--- a/main.go
+++ b/main.go
@@ -20,7 +20,6 @@ import (
 	"os"
 	"os/exec"
 
-	"github.com/polydawn/meep"
 	"github.com/tazjin/kontemplate/context"
 	"github.com/tazjin/kontemplate/templater"
 	"gopkg.in/alecthomas/kingpin.v2"
@@ -30,10 +29,6 @@ const version string = "1.3.0"
 
 // This variable will be initialised by the Go linker during the builder
 var gitHash string
-
-type KubeCtlError struct {
-	meep.AllTraits
-}
 
 var (
 	app = kingpin.New("kontemplate", "simple Kubernetes resource templating")
@@ -180,14 +175,14 @@ func runKubectlWithResources(c *context.Context, kubectlArgs *[]string, resource
 
 		stdin, err := kubectl.StdinPipe()
 		if err != nil {
-			return meep.New(&KubeCtlError{}, meep.Cause(err))
+			return fmt.Errorf("kubectl error: %v", err)
 		}
 
 		kubectl.Stdout = os.Stdout
 		kubectl.Stderr = os.Stderr
 
 		if err = kubectl.Start(); err != nil {
-			return meep.New(&KubeCtlError{}, meep.Cause(err))
+			return fmt.Errorf("kubectl error: %v", err)
 		}
 
 		for _, r := range rs.Resources {

--- a/templater/dns.go
+++ b/templater/dns.go
@@ -14,26 +14,16 @@ package templater
 
 import (
 	"fmt"
-	"github.com/polydawn/meep"
 	"net"
 	"os"
 )
-
-type DNSError struct {
-	meep.TraitAutodescribing
-	meep.TraitCausable
-	Output string
-}
 
 func GetIPsFromDNS(host string) ([]interface{}, error) {
 	fmt.Fprintf(os.Stderr, "Attempting to look up IP for %s in DNS\n", host)
 	ips, err := net.LookupIP(host)
 
 	if err != nil {
-		return nil, meep.New(
-			&DNSError{Output: "IP address lookup failed"},
-			meep.Cause(err),
-		)
+		return nil, fmt.Errorf("IP address lookup failed: %v", err)
 	}
 
 	var result []interface{} = make([]interface{}, len(ips))

--- a/templater/pass.go
+++ b/templater/pass.go
@@ -16,16 +16,8 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
-
-	"github.com/polydawn/meep"
 	"strings"
 )
-
-type PassError struct {
-	meep.TraitAutodescribing
-	meep.TraitCausable
-	Output string
-}
 
 func GetFromPass(key string) (string, error) {
 	fmt.Fprintf(os.Stderr, "Attempting to look up %s in pass\n", key)
@@ -33,10 +25,7 @@ func GetFromPass(key string) (string, error) {
 
 	output, err := pass.CombinedOutput()
 	if err != nil {
-		return "", meep.New(
-			&PassError{Output: string(output)},
-			meep.Cause(err),
-		)
+		return "", fmt.Errorf("Pass lookup failed: %s (%v)", output, err)
 	}
 
 	trimmed := strings.TrimSpace(string(output))

--- a/templater/templater.go
+++ b/templater/templater.go
@@ -20,25 +20,11 @@ import (
 	"text/template"
 
 	"github.com/Masterminds/sprig"
-	"github.com/polydawn/meep"
 	"github.com/tazjin/kontemplate/context"
 	"github.com/tazjin/kontemplate/util"
 )
 
 const failOnMissingKeys string = "missingkey=error"
-
-// Error that is caused by non-existent template files being specified
-type TemplateNotFoundError struct {
-	meep.AllTraits
-	Name string
-	Path string
-}
-
-// Error that is caused during templating, e.g. required value being absent or invalid template format
-type TemplatingError struct {
-	meep.TraitAutodescribing
-	meep.TraitCausable
-}
 
 type RenderedResource struct {
 	Filename string
@@ -83,10 +69,7 @@ func processResourceSet(c *context.Context, rs *context.ResourceSet) (*RenderedR
 	resources, err := processFiles(c, rs, rp, files)
 
 	if err != nil {
-		return nil, meep.New(
-			&TemplateNotFoundError{Name: rs.Name, Path: rs.Path},
-			meep.Cause(err),
-		)
+		return nil, err
 	}
 
 	return &RenderedResourceSet{
@@ -122,10 +105,7 @@ func templateFile(c *context.Context, rs *context.ResourceSet, filename string) 
 	tpl, err := template.New(path.Base(filename)).Funcs(templateFuncs(rs)).Option(failOnMissingKeys).ParseFiles(filename)
 
 	if err != nil {
-		return "", meep.New(
-			&TemplateNotFoundError{Name: filename},
-			meep.Cause(err),
-		)
+		return "", fmt.Errorf("Template %s not found: %v", filename, err)
 	}
 
 	var b bytes.Buffer
@@ -135,10 +115,7 @@ func templateFile(c *context.Context, rs *context.ResourceSet, filename string) 
 	err = tpl.Execute(&b, rs.Values)
 
 	if err != nil {
-		return "", meep.New(
-			&TemplatingError{},
-			meep.Cause(err),
-		)
+		return "", fmt.Errorf("Error while templating %s: %v", filename, err)
 	}
 
 	return b.String(), nil


### PR DESCRIPTION
Removes the old error handling library and switches to plain
fmt.Errorf calls.

There are several reasons for this:

* There are no useful types or handling here anyways, so output format
  is the only priority.
* Users don't care about getting stacktraces.
* My emotional wellbeing.

Fin de siècle.