### PR TITLE
Bump version to 1.4.0

### DIFF
--- a/build-release.sh
+++ b/build-release.sh
@@ -12,7 +12,7 @@ set -ueo pipefail
 
 readonly GIT_HASH="$(git rev-parse --short HEAD)"
 readonly LDFLAGS="-X main.gitHash=${GIT_HASH} -w -s"
-readonly VERSION="1.3.0-${GIT_HASH}"
+readonly VERSION="1.4.0-${GIT_HASH}"
 
 function binary-name() {
     local os="${1}"

--- a/example/some-api/some.cfg
+++ b/example/some-api/some.cfg
@@ -1,0 +1,4 @@
+{
+  "something": 1542,
+  "other-thing": "да"
+}

--- a/main.go
+++ b/main.go
@@ -25,7 +25,7 @@ import (
 	"gopkg.in/alecthomas/kingpin.v2"
 )
 
-const version string = "1.3.0"
+const version string = "1.4.0"
 
 // This variable will be initialised by the Go linker during the builder
 var gitHash string


### PR DESCRIPTION
It's time for a release, maybe a bit unexpected due to how things went.

Anyways, in terms of release process this one doesn't need a release-branch anymore - just a git tag will do now, thanks to Nix :-)