### PR TITLE
Add a new template function called cmd

### DIFF
--- a/docs/templates.md
+++ b/docs/templates.md
@@ -75,6 +75,7 @@ Some template functions come from Go's standard library and are listed in the
 available in kontemplate, as well as three custom functions:
 
 * `json`: Encodes any supplied data structure as JSON.
+* `gitHEAD`: Retrieves the commit hash at Git `HEAD`.
 * `passLookup`: Looks up the supplied key in [pass][].
 * `insertFile`: Insert the contents of the given file in the resource
   set folder as a string.
@@ -96,6 +97,9 @@ certKeyPath: my-website/cert-key
 
 {{ .certKeyPath | passLookup }}
 -> Returns content of 'my-website/cert-key' from pass
+
+{{ gitHEAD }}
+-> Returns the Git commit hash at HEAD.
 ```
 
 ## Conditionals & ranges

--- a/templater/templater.go
+++ b/templater/templater.go
@@ -15,6 +15,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"os/exec"
 	"path"
 	"strings"
 	"text/template"
@@ -169,6 +170,14 @@ func templateFuncs(rs *context.ResourceSet) template.FuncMap {
 		return string(b)
 	}
 	m["passLookup"] = GetFromPass
+	m["gitHEAD"] = func() (string, error) {
+			out, err := exec.Command("sh", "-c", "git rev-parse HEAD").Output()
+			if err != nil {
+				return "", err
+			}
+			output := strings.TrimSpace(string(out))
+			return output, nil
+		}
 	m["lookupIPAddr"] = GetIPsFromDNS
 	m["insertFile"] = func(file string) (string, error) {
 		data, err := ioutil.ReadFile(path.Join(rs.Path, file))


### PR DESCRIPTION
Really enjoying the simplicity of Kontemplate. Thanks for writing it!

I was hoping to add an additional template function called `cmd` that would allow me to execute sh commands from my templates and get string values as returns.

I'm not partial to the name, so feel free to give feedback. `shell` or `exec` could be alternatives. 

🎉 