### PR TITLE
Feature: Add new template function called gitHEAD

### DIFF
--- a/docs/templates.md
+++ b/docs/templates.md
@@ -75,6 +75,7 @@ Some template functions come from Go's standard library and are listed in the
 available in kontemplate, as well as three custom functions:
 
 * `json`: Encodes any supplied data structure as JSON.
+* `gitHEAD`: Retrieves the commit hash at Git `HEAD`.
 * `passLookup`: Looks up the supplied key in [pass][].
 * `insertFile`: Insert the contents of the given file in the resource
   set folder as a string.
@@ -96,6 +97,9 @@ certKeyPath: my-website/cert-key
 
 {{ .certKeyPath | passLookup }}
 -> Returns content of 'my-website/cert-key' from pass
+
+{{ gitHEAD }}
+-> Returns the Git commit hash at HEAD.
 ```
 
 ## Conditionals & ranges

--- a/templater/templater.go
+++ b/templater/templater.go
@@ -15,6 +15,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"os/exec"
 	"path"
 	"strings"
 	"text/template"
@@ -169,6 +170,14 @@ func templateFuncs(rs *context.ResourceSet) template.FuncMap {
 		return string(b)
 	}
 	m["passLookup"] = GetFromPass
+	m["gitHEAD"] = func() (string, error) {
+			out, err := exec.Command("sh", "-c", "git rev-parse HEAD").Output()
+			if err != nil {
+				return "", err
+			}
+			output := strings.TrimSpace(string(out))
+			return output, nil
+		}
 	m["lookupIPAddr"] = GetIPsFromDNS
 	m["insertFile"] = func(file string) (string, error) {
 		data, err := ioutil.ReadFile(path.Join(rs.Path, file))

--- a/templater/templater.go
+++ b/templater/templater.go
@@ -171,7 +171,7 @@ func templateFuncs(rs *context.ResourceSet) template.FuncMap {
 	}
 	m["passLookup"] = GetFromPass
 	m["gitHEAD"] = func() (string, error) {
-			out, err := exec.Command("sh", "-c", "git rev-parse HEAD").Output()
+			out, err := exec.Command("git", "rev-parse", "HEAD").Output()
 			if err != nil {
 				return "", err
 			}


### PR DESCRIPTION
A template function has been added that allows one to template the
Git hash of the surrounding repo. This is useful to be able to inspect the
deployment revision of an object in Kubernetes.

This PR is confirmation that I transfer any copyright of this code to the owner of this repo `tazjin`. 