### PR TITLE
Allow explicit variables to be defined as argument

### DIFF
--- a/context/context.go
+++ b/context/context.go
@@ -12,6 +12,7 @@ package context
 import (
 	"fmt"
 	"path"
+	"strings"
 
 	"github.com/tazjin/kontemplate/util"
 )
@@ -157,4 +158,24 @@ func loadDefaultValues(rs *ResourceSet, c *Context) *map[string]interface{} {
 	// Otherwise we'd have to differentiate between file-not-found-errors (no default values specified) and other
 	// errors here.
 	return &rs.Values
+}
+
+// New variables can be defined or default values overridden with command line arguments when executing kontemplate.
+func (ctx *Context) SetVariablesFromArguments(vars *[]string) error {
+	// Resource set files might not have defined any global variables, if so we have to
+	// create that a map before potentially writing variables into it
+	if ctx.Global == nil {
+		ctx.Global = make(map[string]interface{}, len(*vars))
+	}
+
+	for _, v := range *vars {
+		varParts := strings.Split(v, "=")
+		if len(varParts) != 2 {
+			return fmt.Errorf(`invalid explicit variable provided (%s), name and value should be divided with "="`, v)
+		}
+
+		ctx.Global[varParts[0]] = varParts[1]
+	}
+
+	return nil
 }

--- a/context/context_test.go
+++ b/context/context_test.go
@@ -280,3 +280,25 @@ func TestExplicitSubresourcePathLoading(t *testing.T) {
 		t.Fail()
 	}
 }
+
+func TestSetVariablesFromArguments(t *testing.T) {
+	vars := []string{"version=some-service-version"}
+	ctx, _ := LoadContextFromFile("testdata/default-loading.yaml")
+
+	if err := ctx.SetVariablesFromArguments(&vars); err != nil {
+		t.Error(err)
+	}
+
+	if version := ctx.Global["version"]; version != "some-service-version" {
+		t.Errorf(`Expected variable "version" to have value "some-service-version" but was "%s"`, version)
+	}
+}
+
+func TestSetInvalidVariablesFromArguments(t *testing.T) {
+	vars := []string{"version: some-service-version"}
+	ctx, _ := LoadContextFromFile("testdata/default-loading.yaml")
+
+	if err := ctx.SetVariablesFromArguments(&vars); err == nil {
+		t.Error("Expected invalid variable to return an error")
+	}
+}

--- a/context/testdata/import-vars-override.yaml
+++ b/context/testdata/import-vars-override.yaml
@@ -6,4 +6,5 @@ global:
 import:
   - test-vars.yaml
   - test-vars-override.yaml
-include: []
+include:
+  - name: test-set

--- a/main.go
+++ b/main.go
@@ -37,6 +37,7 @@ var (
 	// Global flags
 	includes = app.Flag("include", "Resource sets to include explicitly").Short('i').Strings()
 	excludes = app.Flag("exclude", "Resource sets to exclude explicitly").Short('e').Strings()
+	variables = app.Flag("var", "Provide variables to templates explicitly").Strings()
 
 	// Commands
 	template          = app.Command("template", "Template resource sets and print them")
@@ -186,6 +187,11 @@ func loadContextAndResources(file *string) (*context.Context, *[]templater.Rende
 	ctx, err := context.LoadContextFromFile(*file)
 	if err != nil {
 		app.Fatalf("Error loading context: %v\n", err)
+	}
+
+	err = ctx.SetVariablesFromArguments(variables)
+	if err != nil {
+		app.Fatalf("Error setting explicit variables in context: %v\n", err)
 	}
 
 	resources, err := templater.LoadAndApplyTemplates(includes, excludes, ctx)

--- a/main.go
+++ b/main.go
@@ -184,14 +184,9 @@ func createCommand() {
 }
 
 func loadContextAndResources(file *string) (*context.Context, *[]templater.RenderedResourceSet) {
-	ctx, err := context.LoadContextFromFile(*file)
+	ctx, err := context.LoadContext(*file, variables)
 	if err != nil {
 		app.Fatalf("Error loading context: %v\n", err)
-	}
-
-	err = ctx.SetVariablesFromArguments(variables)
-	if err != nil {
-		app.Fatalf("Error setting explicit variables in context: %v\n", err)
 	}
 
 	resources, err := templater.LoadAndApplyTemplates(includes, excludes, ctx)

--- a/templater/templater.go
+++ b/templater/templater.go
@@ -111,8 +111,6 @@ func templateFile(c *context.Context, rs *context.ResourceSet, filename string) 
 
 	var b bytes.Buffer
 
-	rs.Values = *util.Merge(&c.Global, &rs.Values)
-
 	err = tpl.Execute(&b, rs.Values)
 
 	if err != nil {


### PR DESCRIPTION
These changes allows variables to be defined as an argument when executing `kontemplate` via one or more `--variable` arguments.

With this in place one can either define new variables or override existing variables loaded from a file:

```
$ kontemplate apply --variable version=v1 example/fancy-app.yaml
```

This avoids the need to write variables into a temporary file that is only needed to provide "external variables" into resource sets.

I'm personally not opinionated about the argument name, more than open for better suggestions like `--set` or similar. Any thoughts?

Closes #122