### PR TITLE
Support importing variables from absolute paths

### DIFF
--- a/context/context_test.go
+++ b/context/context_test.go
@@ -43,7 +43,7 @@ func TestLoadFlatContextFromFile(t *testing.T) {
 				Parent:  "",
 			},
 		},
-		BaseDir: "testdata",
+		BaseDir:      "testdata",
 		ImportedVars: make(map[string]interface{}, 0),
 		ExplicitVars: make(map[string]interface{}, 0),
 	}
@@ -84,14 +84,14 @@ func TestLoadContextWithResourceSetCollections(t *testing.T) {
 				Name: "collection/nested",
 				Path: "collection/nested",
 				Values: map[string]interface{}{
-					"lizards": "good",
+					"lizards":   "good",
 					"globalVar": "lizards",
 				},
 				Include: nil,
 				Parent:  "collection",
 			},
 		},
-		BaseDir: "testdata",
+		BaseDir:      "testdata",
 		ImportedVars: make(map[string]interface{}, 0),
 		ExplicitVars: make(map[string]interface{}, 0),
 	}
@@ -125,7 +125,7 @@ func TestSubresourceVariableInheritance(t *testing.T) {
 				Parent:  "parent",
 			},
 		},
-		BaseDir: "testdata",
+		BaseDir:      "testdata",
 		ImportedVars: make(map[string]interface{}, 0),
 		ExplicitVars: make(map[string]interface{}, 0),
 	}
@@ -157,7 +157,7 @@ func TestSubresourceVariableInheritanceOverride(t *testing.T) {
 				Parent:  "parent",
 			},
 		},
-		BaseDir: "testdata",
+		BaseDir:      "testdata",
 		ImportedVars: make(map[string]interface{}, 0),
 		ExplicitVars: make(map[string]interface{}, 0),
 	}
@@ -221,7 +221,7 @@ func TestValuesOverride(t *testing.T) {
 			"artist": "Pallida",
 			"track":  "Tractor Beam",
 		},
-		"place": "Oslo",
+		"place":     "Oslo",
 		"globalVar": "very global!",
 	}
 
@@ -260,7 +260,7 @@ func TestExplicitPathLoading(t *testing.T) {
 				Parent:  "",
 			},
 		},
-		BaseDir: "testdata",
+		BaseDir:      "testdata",
 		ImportedVars: make(map[string]interface{}, 0),
 		ExplicitVars: make(map[string]interface{}, 0),
 	}
@@ -288,7 +288,7 @@ func TestExplicitSubresourcePathLoading(t *testing.T) {
 				Values: make(map[string]interface{}, 0),
 			},
 		},
-		BaseDir: "testdata",
+		BaseDir:      "testdata",
 		ImportedVars: make(map[string]interface{}, 0),
 		ExplicitVars: make(map[string]interface{}, 0),
 	}

--- a/main.go
+++ b/main.go
@@ -35,8 +35,8 @@ var (
 	app = kingpin.New("kontemplate", "simple Kubernetes resource templating")
 
 	// Global flags
-	includes = app.Flag("include", "Resource sets to include explicitly").Short('i').Strings()
-	excludes = app.Flag("exclude", "Resource sets to exclude explicitly").Short('e').Strings()
+	includes  = app.Flag("include", "Resource sets to include explicitly").Short('i').Strings()
+	excludes  = app.Flag("exclude", "Resource sets to exclude explicitly").Short('e').Strings()
 	variables = app.Flag("var", "Provide variables to templates explicitly").Strings()
 
 	// Commands

--- a/util/util.go
+++ b/util/util.go
@@ -10,10 +10,7 @@
 package util
 
 import (
-	"encoding/json"
-	"fmt"
 	"io/ioutil"
-	"strings"
 
 	"github.com/ghodss/yaml"
 )
@@ -44,19 +41,17 @@ func Merge(in1 *map[string]interface{}, in2 *map[string]interface{}) *map[string
 	return &new
 }
 
-// Loads either a YAML or JSON file from the specified path and deserialises it into the provided interface.
-func LoadJsonOrYaml(filename string, addr interface{}) error {
+// Loads either a YAML or JSON file from the specified path and
+// deserialises it into the provided interface.
+func LoadData(filename string, addr interface{}) error {
 	file, err := ioutil.ReadFile(filename)
 	if err != nil {
 		return err
 	}
 
-	if strings.HasSuffix(filename, "json") {
-		err = json.Unmarshal(file, addr)
-	} else if strings.HasSuffix(filename, "yaml") || strings.HasSuffix(filename, "yml") {
-		err = yaml.Unmarshal(file, addr)
-	} else {
-		return fmt.Errorf("File format not supported. Must be JSON or YAML.")
+	err = yaml.Unmarshal(file, addr)
+	if err != nil {
+		return err
 	}
 
 	return nil


### PR DESCRIPTION
Modifies the logic for importing variables to support absolute paths on the filesystem.

In addition to normal files an absolute path can also be a path such as `/dev/stdin`, which gives users the ability to load extra variables from standard input.

In addition YAML/JSON parsing now use the same library (because - as @cellofellow pointed out in #131 - JSON is a subset of YAML).

This closes #131 