### PR TITLE
Support resource sets pointing at a single template file

### DIFF
--- a/example/other-config.yaml
+++ b/example/other-config.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: extensions/v1beta1
+kind: ConfigMap
+metadata:
+  name: other-config
+data:
+  globalData: {{ .globalVar }}

--- a/example/prod-cluster.yaml
+++ b/example/prod-cluster.yaml
@@ -3,8 +3,15 @@ context: k8s.prod.mydomain.com
 global:
   globalVar: lizards
 include:
+  # By default resource sets are included from a folder with the same
+  # name as the resource set's name
   - name: some-api
     values:
       version: 1.0-0e6884d
       importantFeature: true
       apiPort: 4567
+
+  # Paths can also be specified manually (and point at single template
+  # files!)
+  - name: other-config
+    path: other-config.yaml


### PR DESCRIPTION
Supports resource sets in which the `path` is pointed at a single template file.

Example:

```
context: some-context
include:
  - name: some-resource-set
    path: my-resource.yaml
```

The example folder has been updated with ... an example of this.

This closes #81 (after a long time, sorry @rolftimmermans & @luarx! Things have been turbulent and I haven't had an opportunity!)