### PR TITLE
fix(context): Use SplitN to split CLI variable specifications

### DIFF
--- a/context/context.go
+++ b/context/context.go
@@ -204,7 +204,7 @@ func loadExplicitVars(vars *[]string) (map[string]interface{}, error) {
 	explicitVars := make(map[string]interface{}, len(*vars))
 
 	for _, v := range *vars {
-		varParts := strings.Split(v, "=")
+		varParts := strings.SplitN(v, "=", 2)
 		if len(varParts) != 2 {
 			return nil, fmt.Errorf(`invalid explicit variable provided (%s), name and value should be separated with "="`, v)
 		}


### PR DESCRIPTION
In some cases the value of a variable may contain an equals sign,
which would not work in the previous version.

This uses `SplitN` to split the variable specifier into a
pre-determined number (2) of sub-slices. Further `=`-symbols will then
be included in the second substring.