### PR TITLE
Fix context merging logic regression

### DIFF
--- a/context/context.go
+++ b/context/context.go
@@ -167,8 +167,8 @@ func (ctx *Context) mergeContextValues() []ResourceSet {
 	updated := make([]ResourceSet, len(ctx.ResourceSets))
 
 	for i, rs := range ctx.ResourceSets {
-		merged := loadDefaultValues(&rs, ctx)
-		merged = util.Merge(merged, &ctx.Global)
+		defaultValues := loadDefaultValues(&rs, ctx)
+		merged := util.Merge(&ctx.Global, defaultValues)
 		merged = util.Merge(merged, &ctx.ImportedVars)
 		merged = util.Merge(merged, &ctx.ExplicitVars)
 		rs.Values = *merged


### PR DESCRIPTION
This relates to #142.

In the last release (1.6) I changed the order in which variables were
merged from

    explicit > import > include > default > global

to

    explicit > import > include > global > default

From my POV this was a bug fix, with the reasoning that variables
defined inside of a resource set (defaults) are the "furthest" away
from the most specific definition (i.e. cluster configuration, such as
a context file, is always *more* specific than a resource set).

While I still think this reasoning is "correct", the other side of the
argument is that specificity within a resource set takes precedence
over values that are valid for all resource sets.

This commit reverts the change in the previous version and will be
released as a minor version bump. The next major release of
Kontemplate will include a proper fix with some kind of feature toggle
for this, however I haven't quite figured out the ergonomics yet.

In the meantime breaking the previous behaviour was not the right
thing to do even in the name of theoretical correctness - sorry!