### PR TITLE
Add function to safely check variable existence in templates

### DIFF
--- a/templater/templater.go
+++ b/templater/templater.go
@@ -203,7 +203,13 @@ func templateFuncs(c *context.Context, rs *context.ResourceSet) template.FuncMap
 
 		return string(data), nil
 	}
+	m["default"] = func(defaultVal interface{}, varName string) interface{} {
+		if val, ok := rs.Values[varName]; ok {
+			return val
+		}
 
+		return defaultVal
+	}
 	return m
 }
 

--- a/templater/templater_test.go
+++ b/templater/templater_test.go
@@ -162,3 +162,20 @@ func TestFailOnMissingKeys(t *testing.T) {
 		t.Errorf("Templating failed with unexpected error: %v\n", err)
 	}
 }
+
+func TestDefaultTemplateFunction(t *testing.T) {
+	ctx := context.Context{}
+	resourceSet := context.ResourceSet{}
+
+	res, err := templateFile(&ctx, &resourceSet, "testdata/test-default.txt")
+
+	if err != nil {
+		t.Errorf("Templating with default values should have succeeded.\n")
+		t.Fail()
+	}
+
+	if res.Rendered != "defaultValue\n" {
+		t.Error("Result does not contain expected rendered default value.")
+		t.Fail()
+	}
+}

--- a/templater/testdata/test-default.txt
+++ b/templater/testdata/test-default.txt
@@ -1,0 +1,1 @@
+{{ default "defaultValue" "missingVar" }}


### PR DESCRIPTION
Howdy @tazjin!

These changes adds the `definedOrEmpty` template function which allows templates to get values from possibly non-existent variables in a safe manner.

If no variable exists with the name provided, an empty string will be returned. This makes it a good fit for combining with sprig's `default` function:

```
{{ definedOrEmpty "version" | default gitHEAD }}
```

Would either result in the `version` variable's value, or if it has not been declared, would use the result of `gitHEAD` function instead.

Any thoughts?

*P.S. I'm not opinionated about the function name.*

Refs https://github.com/tazjin/kontemplate/issues/140#issuecomment-397911172