### PR TITLE
Feature: Add toYaml function to templater.

### DIFF
--- a/templater/templater.go
+++ b/templater/templater.go
@@ -23,6 +23,7 @@ import (
 	"github.com/Masterminds/sprig"
 	"github.com/tazjin/kontemplate/context"
 	"github.com/tazjin/kontemplate/util"
+	yaml "gopkg.in/yaml.v2"
 )
 
 const failOnMissingKeys string = "missingkey=error"
@@ -184,6 +185,15 @@ func templateFuncs(c *context.Context, rs *context.ResourceSet) template.FuncMap
 	m["json"] = func(data interface{}) string {
 		b, _ := json.Marshal(data)
 		return string(b)
+	}
+
+	m["toYaml"] = func(v interface{}) string {
+		data, err := yaml.Marshal(v)
+		if err != nil {
+			// Swallow errors inside of a template.
+			return ""
+		}
+		return string(data)
 	}
 	m["passLookup"] = GetFromPass
 	m["gitHEAD"] = func() (string, error) {

--- a/templater/templater.go
+++ b/templater/templater.go
@@ -193,7 +193,7 @@ func templateFuncs(c *context.Context, rs *context.ResourceSet) template.FuncMap
 		data, err := yaml.Marshal(v)
 		if err != nil {
 			// Swallow errors inside of a template.
-			return ""
+			return "", err
 		}
 		return string(data)
 	}


### PR DESCRIPTION
This function will allow to convert interface to Yaml, thus you can use indent function to include keys directly from your ResourcesSets values.

Example Usage
Lets say that you have this ResourcesSets definition:
```yaml
- name: test
  values:
    envVars:
    - name: VALUE_A
      valueFrom:
        configMapKeyRef:
          name: configmap-1
          key: value-a
    - name: RUN_TEST
      value: "true"
```
```yaml
apiVersion: v1
kind: Pod
metadata:
  name: pod-example
spec:
  containers:
  - name: ubuntu
    image: ubuntu:trusty
    env:
    {{- toYaml .envVars | indent 2 }}
    command: ["echo"]
    args: ["Hello World"]
```
@tazjin could you take a look at this and include it in the next release.

Cheers.