### PR TITLE
Feature: Helper template

### DIFF
--- a/context/context.go
+++ b/context/context.go
@@ -33,6 +33,9 @@ type ResourceSet struct {
 
 	// Parent resource set for flattened resource sets. Should not be manually specified.
 	Parent string
+
+	// The template to be include to this resourceSet before renedering
+	TemplateHelper string `json:"helper"`
 }
 
 type Context struct {
@@ -41,6 +44,9 @@ type Context struct {
 
 	// Global variables that should be accessible by all resource sets
 	Global map[string]interface{} `json:"global"`
+
+	// The template to be include to in every resourceSet before renedering
+	GlobalTemplateHelper string `json:"globalHelper"`
 
 	// File names of YAML or JSON files including extra variables that should be globally accessible
 	VariableImportFiles []string `json:"import"`
@@ -132,7 +138,7 @@ func (ctx *Context) loadImportedVariables() (map[string]interface{}, error) {
 // Correctly prepares the file paths for resource sets by inferring implicit paths and flattening resource set
 // collections, i.e. resource sets that themselves have an additional 'include' field set.
 // Those will be regarded as a short-hand for including multiple resource sets from a subfolder.
-// See https://github.com/tazjin/kontemplate/issues/9 for more information.
+// See https://github.com/mrmm/kontemplate/issues/9 for more information.
 func flattenPrepareResourceSetPaths(rs *[]ResourceSet) []ResourceSet {
 	flattened := make([]ResourceSet, 0)
 
@@ -177,7 +183,7 @@ func flattenPrepareResourceSetPaths(rs *[]ResourceSet) []ResourceSet {
 // 5. Explicit values set on the CLI (`--var`)
 //
 // For a discussion on the reasoning behind this order, please consult
-// https://github.com/tazjin/kontemplate/issues/142
+// https://github.com/mrmm/kontemplate/issues/142
 func (ctx *Context) mergeContextValues() []ResourceSet {
 	updated := make([]ResourceSet, len(ctx.ResourceSets))
 

--- a/docs/cluster-config.md
+++ b/docs/cluster-config.md
@@ -14,6 +14,7 @@ global:
   defaultReplicas: 2
 import:
   - test-secrets.yaml
+globalHelper: helper.tpl.yaml
 include:
   - name: gateway
     path: tools/nginx
@@ -40,6 +41,7 @@ include:
         - [`global`](#global)
         - [`import`](#import)
         - [`include`](#include)
+        - [`globalHelper`](#globalHelper)
     - [External variables](#external-variables)
 
 <!-- markdown-toc end -->
@@ -79,6 +81,15 @@ The `include` field contains the actual resource sets to be included in the clus
 Information about the structure of resource sets can be found in the [resource set documentation][].
 
 This field is **required**.
+
+### `globalHelper`
+
+The `globalHelper` field specifies additional templates to load in all ResourceSets when rendering the final manifest.
+
+This fields allow you to `define` named golang template and include them with `template "templateName"`
+function.
+
+This field is **optional**.
 
 ## External variables
 

--- a/docs/resource-sets.md
+++ b/docs/resource-sets.md
@@ -17,6 +17,7 @@ Technically a resource set is simply a folder with a few YAML and/or JSON templa
         - [`path`](#path)
         - [`values`](#values)
         - [`include`](#include)
+        - [`helper`](#helper)
     - [Multiple includes](#multiple-includes)
     - [Nesting resource sets](#nesting-resource-sets)
         - [Caveats](#caveats)
@@ -91,6 +92,16 @@ merged in the same way.
 
 This makes it easy to organise different resource sets as "groups" to include / exclude them collectively
 during runs.
+
+This field is **optional**.
+
+### `helper`
+
+The `helper` field specifies additional templates to load when rendering the final ResourceSet template
+file.
+
+This fields allow you to `define` named golang template and include them with `template "templateName"`
+function.
 
 This field is **optional**.
 


### PR DESCRIPTION
Feature: Add the possibility to define a reusable golang template and import include it inside our kubernetes manifest files. This way we can be sure to minimise the number of needed line to define inside a file and be compilent with the [DRY](https://en.wikipedia.org/wiki/Don%27t_repeat_yourself) principle which the same purpose of templating a file.

You can fine a use-case as example bellow:

file helper.tpl
```yaml
{{ define "hostAliases" }}
hostAliases:
- ip: "{{ .hostIP }}"
  hostnames:
{{ toYaml .hostnames | indent 8 }}
{{ end }}
```

file service_one.tpl.yaml
```yaml
apiVersion: v1
kind: Pod
metadata:
  name: service-one
spec:
{{ template "hostAliases" . }}
  containers:
  - name: nginx
    image: nginx:alpine
```

Cheers.