### PR TITLE
Add timestamp template function to return Unix time

### DIFF
--- a/docs/templates.md
+++ b/docs/templates.md
@@ -79,6 +79,7 @@ available in kontemplate, as well as three custom functions:
 * `passLookup`: Looks up the supplied key in [pass][].
 * `insertFile`: Insert the contents of the given file in the resource
   set folder as a string.
+* `timestamp`: Returns the current Unix time.
 
 ## Examples:
 
@@ -100,6 +101,9 @@ certKeyPath: my-website/cert-key
 
 {{ gitHEAD }}
 -> Returns the Git commit hash at HEAD.
+
+{{ timestamp }}
+-> Returns Unix time.
 ```
 
 ## Conditionals & ranges

--- a/templater/templater.go
+++ b/templater/templater.go
@@ -188,6 +188,14 @@ func templateFuncs(c *context.Context, rs *context.ResourceSet) template.FuncMap
 		return string(b)
 	}
 	m["passLookup"] = GetFromPass
+	m["timestamp"] = func() (string, error) {
+		out, err := exec.Command("date", "+%s").Output()
+		if err != nil {
+			return "", err
+		}
+		output := strings.TrimSpace(string(out))
+		return output, nil
+	}
 	m["gitHEAD"] = func() (string, error) {
 		out, err := exec.Command("git", "-C", c.BaseDir, "rev-parse", "HEAD").Output()
 		if err != nil {


### PR DESCRIPTION
Hey again! 

Just adding another template function so that we can tag resources with a timestamp. 

Im open to a different name if you don't like `timestamp` 

cc: @tazjin 