### PR TITLE
feat(templater): Add insertTemplate function

### DIFF
--- a/docs/templates.md
+++ b/docs/templates.md
@@ -72,12 +72,14 @@ right.
 
 Some template functions come from Go's standard library and are listed in the
 [Go documentation][]. In addition the functions declared by [sprig][] are
-available in kontemplate, as well as three custom functions:
+available in kontemplate, as well as five custom functions:
 
 * `json`: Encodes any supplied data structure as JSON.
 * `gitHEAD`: Retrieves the commit hash at Git `HEAD`.
 * `passLookup`: Looks up the supplied key in [pass][].
 * `insertFile`: Insert the contents of the given file in the resource
+  set folder as a string.
+* `insertTemplate`: Insert the contents of the given template in the resource
   set folder as a string.
 
 ## Examples:

--- a/templater/templater.go
+++ b/templater/templater.go
@@ -205,6 +205,14 @@ func templateFuncs(c *context.Context, rs *context.ResourceSet) template.FuncMap
 
 		return string(data), nil
 	}
+	m["insertTemplate"] = func(file string) (string, error) {
+		data, err := templateFile(c, rs, path.Join(rs.Path, file))
+		if err != nil {
+			return "", err
+		}
+
+		return data.Rendered, nil
+	}
 	m["default"] = func(defaultVal interface{}, varName string) interface{} {
 		if val, ok := rs.Values[varName]; ok {
 			return val

--- a/templater/templater_test.go
+++ b/templater/templater_test.go
@@ -179,3 +179,27 @@ func TestDefaultTemplateFunction(t *testing.T) {
 		t.Fail()
 	}
 }
+
+func TestInsertTemplateFunction(t *testing.T) {
+	ctx := context.Context{}
+	resourceSet := context.ResourceSet{
+		Path: "testdata",
+		Values: map[string]interface{}{
+			"testName":        "TestInsertTemplateFunction",
+		},
+	}
+
+	res, err := templateFile(&ctx, &resourceSet, "testdata/test-insertTemplate.txt")
+
+	if err != nil {
+		t.Error(err)
+		t.Errorf("Templating with an insertTemplate call should have succeeded.\n")
+		t.Fail()
+	}
+
+	if res.Rendered != "Inserting \"Template for test TestInsertTemplateFunction\".\n" {
+		t.Error("Result does not contain expected rendered template value.")
+		t.Error(res.Rendered)
+		t.Fail()
+	}
+}

--- a/templater/testdata/test-insertTemplate.txt
+++ b/templater/testdata/test-insertTemplate.txt
@@ -1,0 +1,1 @@
+Inserting "{{ insertTemplate "test-template.txt" | trim }}".


### PR DESCRIPTION
Similar to insertFile, but runs the templating against the file before inserting.

This is useful for sharing common config between yaml files, e.g. volume mounts in a deployment.yaml and cronjob.yaml, and it's useful to be able to use the `configHash` annotation pattern with a templated configmap.yaml
