### PR TITLE
fix(build): Make Nix build work with recent nixpkgs

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -23,7 +23,9 @@ with pkgs; buildGoPackage rec {
   # Enable checks and configure check-phase to include vet:
   doCheck = true;
   preCheck = ''
-    getGoDirs "" | parallel -j $NIX_BUILD_CORES buildGoDir vet
+    for pkg in $(getGoDirs ""); do
+      buildGoDir vet "$pkg"
+    done
   '';
 
   meta = with lib; {


### PR DESCRIPTION
Changes in the Go build environment for Nix have caused the parallel
vetting to run in a subshell which does not have the required function
definitions.

This commit fixes the error by not running vet in parallel (there's no
point to that anyways as the project is tiny).