### PR TITLE
Ensure resource set paths are made absolute

### DIFF
--- a/context/context_test.go
+++ b/context/context_test.go
@@ -32,7 +32,7 @@ func TestLoadFlatContextFromFile(t *testing.T) {
 		ResourceSets: []ResourceSet{
 			{
 				Name: "some-api",
-				Path: "some-api",
+				Path: "testdata/some-api",
 				Values: map[string]interface{}{
 					"apiPort":          float64(4567), // yep!
 					"importantFeature": true,
@@ -67,7 +67,7 @@ func TestLoadContextWithArgs(t *testing.T) {
 		ResourceSets: []ResourceSet{
 			{
 				Name:   "some-api",
-				Path:   "some-api",
+				Path:   "testdata/some-api",
 				Values: make(map[string]interface{}, 0),
 				Args: []string{
 					"--as=some-user",
@@ -106,7 +106,7 @@ func TestLoadContextWithResourceSetCollections(t *testing.T) {
 		ResourceSets: []ResourceSet{
 			{
 				Name: "some-api",
-				Path: "some-api",
+				Path: "testdata/some-api",
 				Values: map[string]interface{}{
 					"apiPort":          float64(4567), // yep!
 					"importantFeature": true,
@@ -118,7 +118,7 @@ func TestLoadContextWithResourceSetCollections(t *testing.T) {
 			},
 			{
 				Name: "collection/nested",
-				Path: "collection/nested",
+				Path: "testdata/collection/nested",
 				Values: map[string]interface{}{
 					"lizards":   "good",
 					"globalVar": "lizards",
@@ -152,7 +152,7 @@ func TestSubresourceVariableInheritance(t *testing.T) {
 		ResourceSets: []ResourceSet{
 			{
 				Name: "parent/child",
-				Path: "parent/child",
+				Path: "testdata/parent/child",
 				Values: map[string]interface{}{
 					"foo": "bar",
 					"bar": "baz",
@@ -185,7 +185,7 @@ func TestSubresourceVariableInheritanceOverride(t *testing.T) {
 		ResourceSets: []ResourceSet{
 			{
 				Name: "parent/child",
-				Path: "parent/child",
+				Path: "testdata/parent/child",
 				Values: map[string]interface{}{
 					"foo": "newvalue",
 				},
@@ -256,7 +256,7 @@ func TestExplicitPathLoading(t *testing.T) {
 		ResourceSets: []ResourceSet{
 			{
 				Name: "some-api-europe",
-				Path: "some-api",
+				Path: "testdata/some-api",
 				Values: map[string]interface{}{
 					"location": "europe",
 				},
@@ -265,7 +265,7 @@ func TestExplicitPathLoading(t *testing.T) {
 			},
 			{
 				Name: "some-api-asia",
-				Path: "some-api",
+				Path: "testdata/some-api",
 				Values: map[string]interface{}{
 					"location": "asia",
 				},
@@ -296,7 +296,7 @@ func TestExplicitSubresourcePathLoading(t *testing.T) {
 		ResourceSets: []ResourceSet{
 			{
 				Name:   "parent/child",
-				Path:   "parent-path/child-path",
+				Path:   "testdata/parent-path/child-path",
 				Parent: "parent",
 				Values: make(map[string]interface{}, 0),
 			},

--- a/templater/templater.go
+++ b/templater/templater.go
@@ -62,8 +62,7 @@ func LoadAndApplyTemplates(include *[]string, exclude *[]string, c *context.Cont
 func processResourceSet(ctx *context.Context, rs *context.ResourceSet) (*RenderedResourceSet, error) {
 	fmt.Fprintf(os.Stderr, "Loading resources for %s\n", rs.Name)
 
-	resourcePath := path.Join(ctx.BaseDir, rs.Path)
-	fileInfo, err := os.Stat(resourcePath)
+	fileInfo, err := os.Stat(rs.Path)
 	if err != nil {
 		return nil, err
 	}
@@ -78,13 +77,13 @@ func processResourceSet(ctx *context.Context, rs *context.ResourceSet) (*Rendere
 		// list of files instead.
 		// This will end up printing a warning to the user, but it
 		// won't stop the rest of the process.
-		files, _ = ioutil.ReadDir(resourcePath)
+		files, _ = ioutil.ReadDir(rs.Path)
 		resources, err = processFiles(ctx, rs, files)
 		if err != nil {
 			return nil, err
 		}
 	} else {
-		resource, err := templateFile(ctx, rs, resourcePath)
+		resource, err := templateFile(ctx, rs, rs.Path)
 		if err != nil {
 			return nil, err
 		}
@@ -104,7 +103,7 @@ func processFiles(ctx *context.Context, rs *context.ResourceSet, files []os.File
 
 	for _, file := range files {
 		if !file.IsDir() && isResourceFile(file) {
-			path := path.Join(ctx.BaseDir, rs.Path, file.Name())
+			path := path.Join(rs.Path, file.Name())
 			res, err := templateFile(ctx, rs, path)
 
 			if err != nil {


### PR DESCRIPTION
Resolving of files (for `insertFile` and `insertTemplate`) should
always be relative to the resource set location, the previous
behaviour was considered a bug.

This is fixed by ensuring that resource set paths are absolute at
context loading time.