### PR TITLE
insertTemplate now takes an optional map

### DIFF
--- a/deps.nix
+++ b/deps.nix
@@ -100,6 +100,24 @@
     };
   }
   {
+    goPackagePath = "github.com/jinzhu/copier";
+    fetch = {
+      type = "git";
+      url = "https://github.com/jinzhu/copier";
+      rev = "b57f9002281ac48ed8cbc489b1e91121e1a0824c";
+      sha256 = "081fv66lsildg06bzi35canlxj41d1r8s7kysxkxiaci1n3pr053";
+    };
+  }
+  {
+    goPackagePath = "github.com/stretchr/testify";
+    fetch = {
+      type = "git";
+      url = "https://github.com/stretchr/testify";
+      rev = "85f2b59c4459e5bf57488796be8c3667cb8246d6";
+      sha256 = "19xjb0pqwks55src1lkxwvq2aq47bm3qlj3vwiw0xc0qc1rmbq5m";
+    };
+  }
+  {
     goPackagePath = "gopkg.in/yaml.v2";
     fetch = {
       type = "git";

--- a/docs/templates.md
+++ b/docs/templates.md
@@ -138,6 +138,16 @@ ports:
 
 ## InserTemplate with arguments
 
+The insertTemplate-function first arguments is the file-path to the template.
+
+The rest of the arguments should be map-interfaces containing any value.
+These are the variables that will be available inside the template.
+
+The maps assigned will be merged, and ones to the right will take precedence.
+
+If no value is set for the rest-variables, it will default to the global scope.
+
+
 With the following values:
 
 ```yml
@@ -148,7 +158,7 @@ nested:
   mySecondValue: bar
 ```
 
-template.yml
+template.tp;
 
 ```yml
 foo: {{.myValue}}
@@ -157,13 +167,13 @@ bar: {{.mySecondValue}}
 test.yml
 ```yml
 value1:
-{{ insertTemplate "template.yml" | indent 2}}
+{{ insertTemplate "template.tpl" | indent 2}}
 value2:
-{{ insertTemplate "template.yml" .nested | indent 2}}
+{{ insertTemplate "template.tpl" .nested | indent 2}}
 value3:
-{{ dict "myValue" 100 "mySecondValue" 101 | insertTemplate "template.yml" | indent 2}}
+{{ dict "myValue" 100 "mySecondValue" 101 | insertTemplate "template.tpl" | indent 2}}
 value4:
-{{ dict "myValue" 1 "mySecondValue" 2 | insertTemplate "template.yml" | indent 2}}
+{{ dict "myValue" 1 "mySecondValue" 2 | insertTemplate "template.tpl" | indent 2}}
 
 ````
 

--- a/docs/templates.md
+++ b/docs/templates.md
@@ -16,12 +16,13 @@ engine in addition to the cherry-picked features listed here.
 **Table of Contents**
 
 - [Kontemplate templates](#kontemplate-templates)
-    - [Basic variable interpolation](#basic-variable-interpolation)
-        - [Example:](#example)
-    - [Template functions](#template-functions)
-    - [Examples:](#examples)
-    - [Conditionals & ranges](#conditionals--ranges)
-    - [Caveats](#caveats)
+  - [Basic variable interpolation](#basic-variable-interpolation)
+    - [Example:](#example)
+  - [Template functions](#template-functions)
+  - [Examples:](#examples)
+  - [Conditionals & ranges](#conditionals--ranges)
+  - [InserTemplate with arguments](#insertemplate-with-arguments)
+  - [Caveats](#caveats)
 
 <!-- markdown-toc end -->
 
@@ -80,7 +81,7 @@ available in kontemplate, as well as five custom functions:
 * `insertFile`: Insert the contents of the given file in the resource
   set folder as a string.
 * `insertTemplate`: Insert the contents of the given template in the resource
-  set folder as a string.
+  set folder as a string. Takes in an optional dict that can be used in the template.
 
 ## Examples:
 
@@ -133,6 +134,54 @@ ports:
   {{ range .servicePorts }}
   - port: {{ . }}
   {{ end }}
+```
+
+## InserTemplate with arguments
+
+With the following values:
+
+```yml
+myValue: 0
+mySecondValue: 1
+nested:
+  myValue: foo
+  mySecondValue: bar
+```
+
+template.yml
+
+```yml
+foo: {{.myValue}}
+bar: {{.mySecondValue}}
+
+test.yml
+```yml
+value1:
+{{ insertTemplate "template.yml" | indent 2}}
+value2:
+{{ insertTemplate "template.yml" .nested | indent 2}}
+value3:
+{{ dict "myValue" 100 "mySecondValue" 101 | insertTemplate "template.yml" | indent 2}}
+value4:
+{{ dict "myValue" 1 "mySecondValue" 2 | insertTemplate "template.yml" | indent 2}}
+
+````
+
+output
+
+```yml
+value1:
+  foo: 0
+  bar: 1
+value2:
+  foo: foo
+  bar: ba
+value3:
+  foo: 100
+  bar: 101
+value4:
+  foo: 1
+  bar: 2
 ```
 
 Check out the Golang documentation (linked above) for more information about template logic.

--- a/templater/templater.go
+++ b/templater/templater.go
@@ -222,8 +222,6 @@ func templateFuncs(c *context.Context, rs *context.ResourceSet) template.FuncMap
 			if err := mergo.Merge(&rsCopy.Values, params[0], mergo.WithOverride); err != nil {
 				return "", err
 			}
-			fmt.Println("copy", rsCopy)
-			fmt.Println("orig", rs)
 
 			data, err := templateFile(c, &rsCopy, path.Join(rs.Path, file))
 			if err != nil {

--- a/templater/templater.go
+++ b/templater/templater.go
@@ -12,7 +12,6 @@ package templater
 import (
 	"bytes"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -209,18 +208,15 @@ func templateFuncs(c *context.Context, rs *context.ResourceSet) template.FuncMap
 	}
 	m["insertTemplate"] = func(file string, params ...map[string]interface{}) (string, error) {
 
-		if len(params) > 1 {
-			return "", errors.New("insertTemplate can only take a single param")
-		}
-
-		if len(params) == 1 {
+		if len(params) > 0 {
 			rsCopy := context.ResourceSet{}
 			copier.Copy(&rsCopy, rs)
 			rsCopy.Values = map[string]interface{}{}
-			rsCopy.Values = util.CopyMap(rs.Values)
 
-			if err := mergo.Merge(&rsCopy.Values, params[0], mergo.WithOverride); err != nil {
-				return "", err
+			for _, param := range params {
+				if err := mergo.Merge(&rsCopy.Values, param, mergo.WithOverride); err != nil {
+					return "", err
+				}
 			}
 
 			data, err := templateFile(c, &rsCopy, path.Join(rs.Path, file))

--- a/templater/templater_test.go
+++ b/templater/templater_test.go
@@ -10,10 +10,11 @@
 package templater
 
 import (
-	"github.com/tazjin/kontemplate/context"
 	"reflect"
 	"strings"
 	"testing"
+
+	"github.com/tazjin/kontemplate/context"
 )
 
 func TestApplyNoLimits(t *testing.T) {
@@ -185,7 +186,7 @@ func TestInsertTemplateFunction(t *testing.T) {
 	resourceSet := context.ResourceSet{
 		Path: "testdata",
 		Values: map[string]interface{}{
-			"testName":        "TestInsertTemplateFunction",
+			"testName": "TestInsertTemplateFunction",
 		},
 	}
 
@@ -196,10 +197,36 @@ func TestInsertTemplateFunction(t *testing.T) {
 		t.Errorf("Templating with an insertTemplate call should have succeeded.\n")
 		t.Fail()
 	}
-
 	if res.Rendered != "Inserting \"Template for test TestInsertTemplateFunction\".\n" {
 		t.Error("Result does not contain expected rendered template value.")
 		t.Error(res.Rendered)
+		t.Fail()
+	}
+}
+
+func TestInsertTemplateFunctionWithArgs(t *testing.T) {
+	ctx := context.Context{}
+	resourceSet := context.ResourceSet{
+		Path: "testdata",
+		Values: map[string]interface{}{
+			"testName": "TestInsertTemplateFunctionWithArgs",
+			"foo":      "bar",
+		},
+	}
+
+	res, err := templateFile(&ctx, &resourceSet, "testdata/test-insertTemplateWithArgs.txt")
+
+	if err != nil {
+		t.Error(err)
+		t.Errorf("Templating with an insertTemplate call should have succeeded.\n")
+		t.Fail()
+	}
+
+	expected := "Overriding \"Template for test override\".\nOriginal \"Template for test TestInsertTemplateFunctionWithArgs\"."
+	if res.Rendered != expected {
+		t.Error("Result does not contain expected rendered template value.")
+		t.Error(res.Rendered)
+
 		t.Fail()
 	}
 }

--- a/templater/testdata/test-insertTemplateWithArgs.txt
+++ b/templater/testdata/test-insertTemplateWithArgs.txt
@@ -1,2 +1,2 @@
-Overriding "{{ dict "testName" "override" | insertTemplate "test-template.txt" }}". 
-Original "{{ insertTemplate "test-template.txt" }}".
+Overriding "{{ dict "testName" "override" | insertTemplate "test-template.txt" | trim }}".
+Original "{{ insertTemplate "test-template.txt" | trim }}".

--- a/templater/testdata/test-insertTemplateWithArgs.txt
+++ b/templater/testdata/test-insertTemplateWithArgs.txt
@@ -1,0 +1,2 @@
+Overriding "{{ dict "testName" "override" | insertTemplate "test-template.txt" }}". 
+Original "{{ insertTemplate "test-template.txt" }}".

--- a/util/util.go
+++ b/util/util.go
@@ -15,6 +15,20 @@ import (
 	"github.com/ghodss/yaml"
 )
 
+func CopyMap(m map[string]interface{}) map[string]interface{} {
+	cp := make(map[string]interface{})
+	for k, v := range m {
+		vm, ok := v.(map[string]interface{})
+		if ok {
+			cp[k] = CopyMap(vm)
+		} else {
+			cp[k] = v
+		}
+	}
+
+	return cp
+}
+
 // Filenames excluded from templating for the purpose of containing default variable values inside a resource set.
 var DefaultFilenames []string = []string{"default.yml", "default.yaml", "default.json"}
 

--- a/util/util_test.go
+++ b/util/util_test.go
@@ -12,6 +12,8 @@ package util
 import (
 	"reflect"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestMergeWithEmptyMap(t *testing.T) {
@@ -80,4 +82,26 @@ func TestMergeMapsPrecedence(t *testing.T) {
 		t.Error("Map merge precedence test failed.")
 		t.Fail()
 	}
+}
+
+func TestCopyMap(t *testing.T) {
+	m1 := map[string]interface{}{
+		"a": "bbb",
+		"b": map[string]interface{}{
+			"c": 123,
+		},
+	}
+
+	m2 := CopyMap(m1)
+
+	m1["a"] = "zzz"
+	delete(m1, "b")
+
+	require.Equal(t, map[string]interface{}{"a": "zzz"}, m1)
+	require.Equal(t, map[string]interface{}{
+		"a": "bbb",
+		"b": map[string]interface{}{
+			"c": 123,
+		},
+	}, m2)
 }


### PR DESCRIPTION
This PR adds the possibility to reuse templates with different variables using optional rest-arguments to `insertTemplate`. The rest-arguments should be maps, and are merged together into a new map. This new map are then the variables available inside the template. If no rest-arguments are given, it will default to the global variables, so no breaking change here.

Please see the updated documentation for more info.

All tests are passing.

I hope this feature is a welcome addition, and that it will make it to the next release of kontemplate.

### Why I think this feature is useful

This can helpful in reusing the same small templates in various places. Kubernetes-yml is very repetative. Most of the are almost just copies of each-other, with just a few minor changes. With this, we can very easily create a service, most of deployment etc, using default-variables, and then add a few variables that are different. For instance, the name and ports here are spread around multiple places.

For us, we see a very nice benefit to easier keep our docker-compose-yml in sync with our kubernetes-yml. Yes, we also generate docker-compose-files with kontemplate. We use docker-compose for local development. The most important part that need to be in sync here are the environment-variables, which are in a bit of different format. With this feature, we can do something like this:

kube-env.tpl
```yml
env:
  {{- range $key, $value := . }}
  - name: {{ $key }}
    value: {{ $value }}
  {{- end }}
```

docker-env.yml
```yml
environment:
  {{- range $key, $value := . }}
  {{ $key }}: {{ $value }}
  {{- end }}
```

Then, in our docker/kubernetes templates:

```yml
... # Rest of downloader-deployment
 {{ insertTemplate ._envTemplate .downloaderEnvVar }}
...
```

It will then create environment-variables for every key/value in `downloaderEnvVar` that maps correctly with both kubernetes and docker, depending on our target.